### PR TITLE
docs(changelog): add 1.2.4 section & release attribution corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 _No changes yet._
 
+## [1.2.4] - 2025-11-12
+### Changed
+- Changelog corrected to accurately attribute ComfyUI 0.3.65+ compatibility fix to 1.2.3 (added Errata under 1.2.2).
+
+### Internal
+- Merge PR #53 (documentation alignment); no functional code changes beyond prior releases.
+
+### Notes
+- Pure documentation / release metadata correction; users on 1.2.3 already have the fix.
+
 ## [1.2.3] - 2025-11-13
 ### Fixed
 - Resolved AttributeError in ComfyUI 0.3.65+ cache flows (compat wrapper + capture robustness).
@@ -158,7 +168,8 @@ Note: 1.0.0 was the first public registry release; this minor release formalizes
 
 ---
 
-[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.2...HEAD
+[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.0...v1.2.1


### PR DESCRIPTION
### Summary
Adds the 1.2.4 changelog section and corrects release attribution:
- Moves ComfyUI 0.3.65+ compatibility fix attribution (AttributeError + `get_cache` alias) firmly to 1.2.3.
- Adds explicit Errata in 1.2.2 clarifying the fix was not shipped there.
- Documents that 1.2.4 is a documentation-only correction (no functional changes).

### Rationale
The v1.2.2 tag was cut prior to merging the compatibility fix branch. This PR ensures historical accuracy without retagging or rewriting published history.

### Scope
- CHANGELOG.md only.
- Tag `v1.2.4` already points to the commit; merging this PR aligns master with the tag.

### Release Guidance
Users on 1.2.3 have the fix; 1.2.4 is optional unless they need precise release notes.

### No Code Changes
No runtime, API, or metadata logic altered.