### PR TITLE
Fixes issue #78: An embedding parenthesized in a prompt text is not included in the image metadata

### DIFF
--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -45,9 +45,9 @@ except (ImportError, ModuleNotFoundError):  # noqa: BLE001 - provide minimal stu
         """A stub for the `unescape_important` function."""
         return x
 
-    def token_weights(x):
+    def token_weights(string, current_weight):
         """A stub for the `token_weights` function."""
-        return []
+        return [(string, current_weight)]
 
 
 from ..utils.embedding import get_embedding_file_path
@@ -882,7 +882,7 @@ def _extract_embedding_candidates(text, input_data):
 
     try:
         escaped = escape_important(text)
-        parsed_weights = token_weights(escaped)
+        parsed_weights = token_weights(escaped, 1.0)
     except Exception as err:  # pragma: no cover - defensive
         logger.debug("[Metadata Lib] Failed parsing token weights for embeddings: %r", err)
         parsed_weights = [(text, 1.0)]


### PR DESCRIPTION
This PR fixes #78.

I believe the cause of the issue is a wrong use of the `token_weights` function, imported from `comfy.sd1_clip` in `saveimage_unimeta/defs/formatters.py`. It has two required arguments, but the embedding-extraction code in `formatters.py` tries to call it with only one argument. Python throws an exception, and it is caught by a try-except block that has a comment `# pragma: no cover - defensive`. Then, the code falls back to an operation similar to `tokenize_with_weight( ..., disable_weights=True)`. As a result, the `SaveImage w/ Metadata Universal` node ignores the weight (strength) modification syntax, and the embedding extraction logic malfunctions.