### PR TITLE
Fixes issue #79: rgthree Power Lora Loader

### DIFF
--- a/saveimage_unimeta/defs/ext/rgthree.py
+++ b/saveimage_unimeta/defs/ext/rgthree.py
@@ -59,23 +59,21 @@ def get_lora_strength(node_id, obj, prompt, extra_data, outputs, input_data):
 
 def get_lora_data(input_data, attribute):
     """Helper to extract data from active LoRA inputs on a Power Lora Loader."""
-    if not isinstance(input_data, list) or not input_data:
+    try:
+        batch = input_data[0]
+        results = []
+        for key, value in batch.items():
+            if not key.startswith("lora_"):
+                continue
+            if not value[0]["on"]:
+                continue
+            candidate = value[0].get(attribute)
+            if candidate is None:
+                continue
+            results.append(candidate)
+        return results
+    except Exception:
         return []
-    batch = input_data[0]
-    if not isinstance(batch, dict):
-        return []
-    results = []
-    for key, value in batch.items():
-        if not key.startswith("lora_"):
-            continue
-        if not value[0]["on"]:
-            continue
-        candidate = value[0].get(attribute)
-        if candidate is None:
-            continue
-        results.append(candidate)
-    return results
-
 
 def get_lora_model_name_stack(node_id, obj, prompt, extra_data, outputs, input_data):
     """Selector for LoRA names from rgthree's Lora Loader Stack."""


### PR DESCRIPTION
This PR fixes #79.

I believe the issue is caused by two independent bugs in `defs/ext/rgthree.py`.
1. `rgthree.py` contains an import that start with `from saveimage_unimeta.defs.validators import`. It works only in testing (`pytest`). As a result, `rgthree.py` throws an exception when imported in ComfyUI, and `_load_extensions()` in `defs/__init__.py` ignores it, making the support code for Power Lora Loader unavialable.
2. `get_lora_data(input_data, attribute)` in `rgthree.py` checks whether `input_data` is a list and stops working if it is not. However, `input_data` is actually a tuple rather than a list, so this method always reports that no LoRA is enabled in a Power Lora Loader node. (I don't know whether it was a list in older versions of ComfyUI or rgthree and changed recently. I'm quite secure, however, that it is always a tuple when used with ComfyUI version 0.10.0 and rgthree-comfy 1.0.251211205, the latest version.)

Note that we can't simply change `isinstance(input_data, list)` to `isinstance(input_data, tuple)` in `get_lora_data` to fix the second bug, because when running `pytest`, it receives a list. I think this is suitable for EAFP over LBYL.