### PR TITLE
A tentative fix for issue #92: explicitly adds "Prompt (LoraManager)" in the involved lists

### DIFF
--- a/saveimage_unimeta/defs/ext/lora_manager.py
+++ b/saveimage_unimeta/defs/ext/lora_manager.py
@@ -20,7 +20,10 @@ Attributes:
 # https://github.com/willmiao/ComfyUI-Lora-Manager
 import json
 import logging
-
+from ..validators import (
+    is_positive_prompt,
+    is_negative_prompt
+)
 from ...utils.lora import (
     coerce_first,
     parse_lora_syntax,
@@ -363,4 +366,8 @@ CAPTURE_FIELD_LIST = {
         MetaField.LORA_STRENGTH_MODEL: {"selector": get_lora_model_strengths},
         MetaField.LORA_STRENGTH_CLIP: {"selector": get_lora_clip_strengths},
     },
+    "Prompt (LoraManager)": {
+        MetaField.POSITIVE_PROMPT: {'field_name': "text", 'validate': is_positive_prompt},
+        MetaField.NEGATIVE_PROMPT: {'field_name': "text", 'validate': is_negative_prompt},
+    }
 }

--- a/saveimage_unimeta/defs/validators.py
+++ b/saveimage_unimeta/defs/validators.py
@@ -21,6 +21,7 @@ def _is_text_encoder(class_type: str) -> bool:
         "CLIPTextEncode",
         "CLIPTextEncodeFlux",
         "TextEncodeQwenImageEdit",
+        "Prompt (LoraManager)",
     }
     if ct in KNOWN:
         return True


### PR DESCRIPTION
This is a draft PR not ready for merge.

Investigating the issue #92, I found that the Prompt (LoraManager) node is not considered a _text encoder_ node by ComfyUI_SaveImageWithMetaDataUniversal. So, I added it to the lists, and this fix seems working fine.

However, I don't think the current change to `validator.py` is not good, because it hard-codes the name of a particular third-party custom node to the main part of ComfyUI_SaveImageWithMetaDataUniversal. I think such a _ComfyUI-Lora-Manager_-specific code should only be in `saveimage_unimeta/defs/ext/lora_manager.py`, although I have no good idea for the moment.

Any suggestions on how we can implement the fix in a cleaner way?