### PR TITLE
Dev/copilot/fix lora manager hash calculation 2

### DIFF
--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -10,6 +10,7 @@ Includes:
 
 import logging
 import os
+import platform
 import re
 
 import folder_paths
@@ -21,6 +22,151 @@ import json
 _LORA_INDEX: dict[str, dict[str, str]] | None = None
 _LORA_INDEX_BUILT: bool = False
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# LoraManager compat helpers – read extra lora paths from its settings.json
+# ---------------------------------------------------------------------------
+# Directory names the comfyui-lora-manager plugin is commonly installed under.
+_LORA_MANAGER_DIR_NAMES: tuple[str, ...] = (
+    "comfyui-lora-manager",
+    "ComfyUI-Lora-Manager",
+    "ComfyUI-LoRA-Manager",
+    "comfyui_lora_manager",
+    "ComfyUI_Lora_Manager",
+)
+# The app name used by LoraManager for its platformdirs user-config directory.
+_LORA_MANAGER_APP_NAME = "ComfyUI-LoRA-Manager"
+
+
+def _find_lora_manager_root() -> str | None:
+    """Locate the comfyui-lora-manager custom node directory, or None if not installed.
+
+    Derives the ``custom_nodes/`` parent from this file's own path
+    (lora.py → utils/ → saveimage_unimeta/ → plugin_root/ → custom_nodes/)
+    and then checks common directory names for the LoraManager plugin.
+    """
+    try:
+        # Walk up four dirname levels: lora.py -> utils -> saveimage_unimeta -> plugin_root -> custom_nodes
+        custom_nodes_dir = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
+        for name in _LORA_MANAGER_DIR_NAMES:
+            candidate = os.path.join(custom_nodes_dir, name)
+            if os.path.isdir(candidate):
+                return candidate
+    except Exception:
+        pass
+    return None
+
+
+def _get_lora_manager_user_config_path() -> str | None:
+    """Return the platform-specific user-config path for LoraManager's settings.json.
+
+    Tries ``platformdirs`` first (same library LoraManager itself uses), then
+    falls back to per-platform manual derivation so we don't require it as a
+    hard dependency.
+    """
+    app = _LORA_MANAGER_APP_NAME
+    try:
+        import platformdirs  # available when LoraManager is installed
+        return os.path.join(platformdirs.user_config_dir(app, appauthor=False), "settings.json")
+    except ImportError:
+        pass
+    # Manual fallback per platform
+    try:
+        system = platform.system()
+        if system == "Windows":
+            base = os.environ.get("APPDATA") or os.path.expanduser(os.path.join("~", "AppData", "Roaming"))
+            return os.path.join(base, app, "settings.json")
+        if system == "Darwin":
+            return os.path.expanduser(os.path.join("~", "Library", "Application Support", app, "settings.json"))
+        # Linux / other POSIX
+        base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser(os.path.join("~", ".config"))
+        return os.path.join(base, app, "settings.json")
+    except Exception:
+        return None
+
+
+def _read_lora_manager_settings(plugin_root: str) -> dict | None:
+    """Parse LoraManager's settings.json, handling portable vs user-config locations.
+
+    Resolution order (mirrors LoraManager's own ``ensure_settings_file`` logic):
+
+    1. **Portable mode** – ``<plugin_root>/settings.json`` exists *and* contains
+       ``"use_portable_settings": true``.
+    2. **User-config mode** – platform user-config directory
+       (e.g. ``%APPDATA%\\ComfyUI-LoRA-Manager\\settings.json`` on Windows).
+    3. **Legacy fallback** – ``<plugin_root>/settings.json`` without the portable
+       flag (present before first migration to user-config dir).
+    """
+    portable_path = os.path.join(plugin_root, "settings.json")
+
+    # 1. Portable mode
+    if os.path.isfile(portable_path):
+        try:
+            with open(portable_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            if data.get("use_portable_settings"):
+                return data
+        except Exception:
+            pass
+
+    # 2. User-config directory
+    user_path = _get_lora_manager_user_config_path()
+    if user_path and os.path.isfile(user_path):
+        try:
+            with open(user_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            pass
+
+    # 3. Legacy: settings.json in plugin root without portable flag
+    if os.path.isfile(portable_path):
+        try:
+            with open(portable_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            pass
+
+    return None
+
+
+def _get_lora_manager_lora_paths() -> list[str]:
+    """Return lora directory paths from LoraManager's settings.json.
+
+    Reads from both ``extra_folder_paths.loras`` (paths exclusive to LoraManager)
+    and ``folder_paths.loras`` (which may differ from ComfyUI's paths when the
+    user has activated a non-default LoraManager library).
+
+    Returns an empty list if LoraManager is not installed, has no settings file,
+    or has no additional lora paths configured.
+    """
+    plugin_root = _find_lora_manager_root()
+    if not plugin_root:
+        return []
+
+    settings = _read_lora_manager_settings(plugin_root)
+    if not settings or not isinstance(settings, dict):
+        return []
+
+    paths: list[str] = []
+    for key in ("extra_folder_paths", "folder_paths"):
+        section = settings.get(key)
+        if not isinstance(section, dict):
+            continue
+        for p in section.get("loras", []):
+            if isinstance(p, str) and p.strip():
+                paths.append(p.strip())
+
+    # Deduplicate (case-insensitive on Windows) while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for p in paths:
+        norm = os.path.normcase(os.path.normpath(p))
+        if norm not in seen:
+            seen.add(norm)
+            unique.append(p)
+    return unique
 
 
 def build_lora_index() -> None:
@@ -47,7 +193,21 @@ def build_lora_index() -> None:
     lora_paths = folder_paths.get_folder_paths("loras")
     extensions = list(SUPPORTED_MODEL_EXTENSIONS)
 
-    for lora_dir in lora_paths:
+    # Include extra lora paths registered only with LoraManager (not ComfyUI's folder_paths).
+    extra_lm_paths = _get_lora_manager_lora_paths()
+    if extra_lm_paths:
+        logger.info("[Metadata Lib] Found %d extra LoRA path(s) from LoraManager settings.", len(extra_lm_paths))
+
+    # Deduplicate across both sources (case-insensitive on Windows) to avoid walking the same directory twice.
+    seen_dirs: set[str] = set()
+    all_lora_dirs: list[str] = []
+    for d in list(lora_paths) + extra_lm_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_lora_dirs.append(d)
+
+    for lora_dir in all_lora_dirs:
         for root, _, files in os.walk(lora_dir):
             for file in files:
                 file_base, file_ext = os.path.splitext(file)

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -55,7 +55,10 @@ def _find_lora_manager_root() -> str | None:
             if os.path.isdir(candidate):
                 return candidate
     except Exception:
-        pass
+        logger.debug(
+            "Unexpected error while locating LoraManager plugin directory.",
+            exc_info=True,
+        )
     return None
 
 
@@ -115,7 +118,7 @@ def _read_lora_manager_settings(plugin_root: str) -> dict | None:
             if data.get("use_portable_settings"):
                 return data
         except Exception:
-            pass
+            logger.debug("Failed to parse LoraManager settings at %r.", portable_path, exc_info=True)
 
     # 2. User-config directory
     user_path = _get_lora_manager_user_config_path()
@@ -124,7 +127,7 @@ def _read_lora_manager_settings(plugin_root: str) -> dict | None:
             with open(user_path, encoding="utf-8") as fh:
                 return json.load(fh)
         except Exception:
-            pass
+            logger.debug("Failed to parse LoraManager settings at %r.", user_path, exc_info=True)
 
     # 3. Legacy: settings.json in plugin root without portable flag
     if os.path.isfile(portable_path):
@@ -132,7 +135,7 @@ def _read_lora_manager_settings(plugin_root: str) -> dict | None:
             with open(portable_path, encoding="utf-8") as fh:
                 return json.load(fh)
         except Exception:
-            pass
+            logger.debug("Failed to parse LoraManager settings at %r.", portable_path, exc_info=True)
 
     return None
 

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -72,6 +72,12 @@ def _get_lora_manager_user_config_path() -> str | None:
         return os.path.join(platformdirs.user_config_dir(app, appauthor=False), "settings.json")
     except ImportError:
         pass
+    except Exception:
+        logger.debug(
+            "Failed to resolve LoraManager user_config_dir via platformdirs; "
+            "falling back to manual path derivation.",
+            exc_info=True,
+        )
     # Manual fallback per platform
     try:
         system = platform.system()

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -181,6 +181,8 @@ def build_lora_index() -> None:
 
         * Deduplication is case-insensitive on Windows (``os.path.normcase`` + ``normpath``) so
           directories that appear in both sources are only walked once.
+        * ComfyUI standard paths take precedence — they are walked first, so a
+          filename in a standard directory shadows the same filename in a LoraManager-only path.
         * Recursively walks subdirectories within each unique directory.
         * Records the FIRST occurrence of each base filename (stem) only.
         * Supported extensions: ``.safetensors``, ``.st``, ``.pt``, ``.bin``, ``.ckpt``.
@@ -200,19 +202,39 @@ def build_lora_index() -> None:
     lora_paths = folder_paths.get_folder_paths("loras")
     extensions = list(SUPPORTED_MODEL_EXTENSIONS)
 
-    # Include extra lora paths registered only with LoraManager (not ComfyUI's folder_paths).
     extra_lm_paths = _get_lora_manager_lora_paths()
-    if extra_lm_paths:
-        logger.info("[Metadata Lib] Found %d extra LoRA path(s) from LoraManager settings.", len(extra_lm_paths))
 
-    # Deduplicate across both sources (case-insensitive on Windows) to avoid walking the same directory twice.
+    # Deduplicate across both sources (case-insensitive on Windows) to avoid
+    # walking the same directory twice. Standard ComfyUI paths are added first
+    # so they take precedence in the filename-stem index.
     seen_dirs: set[str] = set()
     all_lora_dirs: list[str] = []
-    for d in list(lora_paths) + extra_lm_paths:
+
+    for d in lora_paths:
         norm = os.path.normcase(os.path.normpath(d))
         if norm not in seen_dirs:
             seen_dirs.add(norm)
             all_lora_dirs.append(d)
+
+    extra_unique_dirs: list[str] = []
+    for d in extra_lm_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_lora_dirs.append(d)
+            extra_unique_dirs.append(d)
+
+    if extra_lm_paths:
+        if extra_unique_dirs:
+            logger.info(
+                "[Metadata Lib] Found %d extra LoRA path(s) from LoraManager settings.",
+                len(extra_unique_dirs),
+            )
+        else:
+            logger.info(
+                "[Metadata Lib] LoraManager settings.json defined LoRA paths,"
+                " but all are already covered by existing LoRA directories.",
+            )
 
     for lora_dir in all_lora_dirs:
         for root, _, files in os.walk(lora_dir):

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -173,8 +173,15 @@ def build_lora_index() -> None:
     """Populate (idempotently) the in-memory LoRA file index.
 
     Scan order & behavior:
-        * Enumerates every directory in ``folder_paths.get_folder_paths('loras')``.
-        * Recursively walks subdirectories.
+        * Enumerates every directory from two sources, merged and deduplicated:
+
+          1. ``folder_paths.get_folder_paths('loras')`` — standard ComfyUI LoRA paths.
+          2. ``_get_lora_manager_lora_paths()`` — any additional paths registered only with
+             LoraManager (via its ``extra_folder_paths`` or ``folder_paths`` settings).
+
+        * Deduplication is case-insensitive on Windows (``os.path.normcase`` + ``normpath``) so
+          directories that appear in both sources are only walked once.
+        * Recursively walks subdirectories within each unique directory.
         * Records the FIRST occurrence of each base filename (stem) only.
         * Supported extensions: ``.safetensors``, ``.st``, ``.pt``, ``.bin``, ``.ckpt``.
 

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -102,6 +102,7 @@ def test_user_config_path_returns_settings_json_string():
 def test_user_config_path_linux_manual_fallback(monkeypatch):
     """Falls back to ~/.config/ComfyUI-LoRA-Manager/settings.json on Linux when no platformdirs."""
     import builtins
+    import sys
     real_import = builtins.__import__
 
     def _block_platformdirs(name, *args, **kwargs):
@@ -109,6 +110,9 @@ def test_user_config_path_linux_manual_fallback(monkeypatch):
             raise ImportError("blocked for test")
         return real_import(name, *args, **kwargs)
 
+    # Evict platformdirs from sys.modules so the import statement inside the
+    # function isn't bypassed by the module cache, making the __import__ patch reliable.
+    monkeypatch.delitem(sys.modules, "platformdirs", raising=False)
     monkeypatch.setattr(builtins, "__import__", _block_platformdirs)
     monkeypatch.setattr("platform.system", lambda: "Linux")
     monkeypatch.setenv("XDG_CONFIG_HOME", "/custom/config")

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -124,6 +124,7 @@ def test_user_config_path_linux_manual_fallback(monkeypatch):
 def test_user_config_path_windows_manual_fallback(monkeypatch):
     """Falls back to %APPDATA%\\ComfyUI-LoRA-Manager\\settings.json on Windows."""
     import builtins
+    import sys
     real_import = builtins.__import__
 
     def _block_platformdirs(name, *args, **kwargs):
@@ -131,6 +132,9 @@ def test_user_config_path_windows_manual_fallback(monkeypatch):
             raise ImportError("blocked for test")
         return real_import(name, *args, **kwargs)
 
+    # Evict platformdirs from sys.modules so the import statement inside the
+    # function isn't bypassed by the module cache, making the __import__ patch reliable.
+    monkeypatch.delitem(sys.modules, "platformdirs", raising=False)
     monkeypatch.setattr(builtins, "__import__", _block_platformdirs)
     monkeypatch.setattr("platform.system", lambda: "Windows")
     appdata = r"C:\Users\Tester\AppData\Roaming"

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -52,8 +52,6 @@ def test_find_lora_manager_root_finds_hyphenated_name(monkeypatch, tmp_path):
     target = tmp_path / "comfyui-lora-manager"
     target.mkdir()
 
-    real_isdir = os.path.isdir
-
     def _patched(path):
         if path == str(target):
             return True
@@ -131,10 +129,11 @@ def test_user_config_path_windows_manual_fallback(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", _block_platformdirs)
     monkeypatch.setattr("platform.system", lambda: "Windows")
-    monkeypatch.setenv("APPDATA", r"C:\Users\Tester\AppData\Roaming")
+    appdata = r"C:\Users\Tester\AppData\Roaming"
+    monkeypatch.setenv("APPDATA", appdata)
 
     path = _get_lora_manager_user_config_path()
-    assert path == r"C:\Users\Tester\AppData\Roaming\ComfyUI-LoRA-Manager\settings.json"
+    assert path == os.path.join(appdata, "ComfyUI-LoRA-Manager", "settings.json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -2,11 +2,8 @@
 
 import json
 import os
-import shutil
-import tempfile
 
 import folder_paths
-import pytest
 
 from saveimage_unimeta.utils import lora as lora_mod
 from saveimage_unimeta.utils.lora import (

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -1,0 +1,388 @@
+"""Tests for LoraManager settings-reading helpers and their integration with build_lora_index."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import folder_paths
+import pytest
+
+from saveimage_unimeta.utils import lora as lora_mod
+from saveimage_unimeta.utils.lora import (
+    _find_lora_manager_root,
+    _get_lora_manager_lora_paths,
+    _get_lora_manager_user_config_path,
+    _read_lora_manager_settings,
+    build_lora_index,
+    find_lora_info,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_index():
+    lora_mod._LORA_INDEX = None
+    lora_mod._LORA_INDEX_BUILT = False
+
+
+def _make_settings(extra_dir: str = "", folder_dir: str = "", portable: bool = False) -> dict:
+    """Build a minimal LoraManager settings dict for testing."""
+    data: dict = {}
+    if portable:
+        data["use_portable_settings"] = True
+    if extra_dir:
+        data["extra_folder_paths"] = {"loras": [extra_dir]}
+    if folder_dir:
+        data["folder_paths"] = {"loras": [folder_dir]}
+    return data
+
+
+# ---------------------------------------------------------------------------
+# _find_lora_manager_root
+# ---------------------------------------------------------------------------
+
+def test_find_lora_manager_root_returns_none_when_no_candidates(monkeypatch):
+    """Returns None when no recognised LoraManager directory exists under custom_nodes."""
+    monkeypatch.setattr(os.path, "isdir", lambda _path: False)
+    assert _find_lora_manager_root() is None
+
+
+def test_find_lora_manager_root_finds_hyphenated_name(monkeypatch, tmp_path):
+    """Detects 'comfyui-lora-manager' (the canonical install name)."""
+    target = tmp_path / "comfyui-lora-manager"
+    target.mkdir()
+
+    real_isdir = os.path.isdir
+
+    def _patched(path):
+        if path == str(target):
+            return True
+        # Return False for all paths EXCEPT the one we fabricated to avoid noise from
+        # real filesystem checks in the standard dirname chain.
+        return False
+
+    monkeypatch.setattr(os.path, "isdir", _patched)
+    # Override "abspath(__file__)" for the module so the dirname chain resolves to tmp_path.
+    # lora.py: utils/lora.py → utils → saveimage_unimeta → plugin_root → custom_nodes
+    # We need dirname * 4 from __file__ to land on tmp_path.
+    fake_file = str(tmp_path / "cn" / "Plug" / "pkg" / "utils" / "lora.py")
+
+    orig_abspath = os.path.abspath
+
+    def _fake_abspath(p):
+        if p == lora_mod.__file__:
+            return fake_file
+        return orig_abspath(p)
+
+    monkeypatch.setattr(os.path, "abspath", _fake_abspath)
+    # Rebuild target based on the fake __file__ dirname chain.
+    fake_cn_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(fake_file))))
+    expected = os.path.join(fake_cn_dir, "comfyui-lora-manager")
+
+    # Make the patched isdir return True for the expected path.
+    def _patched2(path):
+        return path == expected
+
+    monkeypatch.setattr(os.path, "isdir", _patched2)
+    result = _find_lora_manager_root()
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# _get_lora_manager_user_config_path
+# ---------------------------------------------------------------------------
+
+def test_user_config_path_returns_settings_json_string():
+    """Returns a non-empty string ending in settings.json."""
+    path = _get_lora_manager_user_config_path()
+    assert path is not None
+    assert isinstance(path, str)
+    assert path.endswith("settings.json")
+    assert "ComfyUI-LoRA-Manager" in path
+
+
+def test_user_config_path_linux_manual_fallback(monkeypatch):
+    """Falls back to ~/.config/ComfyUI-LoRA-Manager/settings.json on Linux when no platformdirs."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _block_platformdirs(name, *args, **kwargs):
+        if name == "platformdirs":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_platformdirs)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/custom/config")
+
+    path = _get_lora_manager_user_config_path()
+    assert path == os.path.join("/custom/config", "ComfyUI-LoRA-Manager", "settings.json")
+
+
+def test_user_config_path_windows_manual_fallback(monkeypatch):
+    """Falls back to %APPDATA%\\ComfyUI-LoRA-Manager\\settings.json on Windows."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _block_platformdirs(name, *args, **kwargs):
+        if name == "platformdirs":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_platformdirs)
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setenv("APPDATA", r"C:\Users\Tester\AppData\Roaming")
+
+    path = _get_lora_manager_user_config_path()
+    assert path == r"C:\Users\Tester\AppData\Roaming\ComfyUI-LoRA-Manager\settings.json"
+
+
+# ---------------------------------------------------------------------------
+# _read_lora_manager_settings
+# ---------------------------------------------------------------------------
+
+def test_read_settings_portable_mode(tmp_path):
+    """Reads settings.json from plugin root when use_portable_settings is True."""
+    settings = _make_settings(extra_dir="/loras/extra", portable=True)
+    (tmp_path / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+
+    result = _read_lora_manager_settings(str(tmp_path))
+    assert result is not None
+    assert result["use_portable_settings"] is True
+    assert result["extra_folder_paths"]["loras"] == ["/loras/extra"]
+
+
+def test_read_settings_user_config_mode(tmp_path, monkeypatch):
+    """Reads settings.json from user config dir when portable mode is off."""
+    cfg_dir = tmp_path / "user_config"
+    cfg_dir.mkdir()
+    settings = _make_settings(extra_dir="/loras/user")
+    (cfg_dir / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_user_config_path", lambda: str(cfg_dir / "settings.json"))
+
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    # No settings.json in plugin root  → must fall back to user config
+    result = _read_lora_manager_settings(str(plugin_root))
+    assert result is not None
+    assert result["extra_folder_paths"]["loras"] == ["/loras/user"]
+
+
+def test_read_settings_legacy_fallback(tmp_path, monkeypatch):
+    """Falls back to plugin-root settings.json that lacks the portable flag."""
+    settings = _make_settings(extra_dir="/loras/legacy")
+    (tmp_path / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+
+    # No user-config file exists
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_user_config_path", lambda: str(tmp_path / "nonexistent.json"))
+
+    result = _read_lora_manager_settings(str(tmp_path))
+    assert result is not None
+    assert result["extra_folder_paths"]["loras"] == ["/loras/legacy"]
+
+
+def test_read_settings_portable_wins_over_user_config(tmp_path, monkeypatch):
+    """Portable mode file takes precedence over user-config file."""
+    portable_settings = _make_settings(extra_dir="/loras/portable", portable=True)
+    (tmp_path / "settings.json").write_text(json.dumps(portable_settings), encoding="utf-8")
+
+    user_cfg = tmp_path / "user.json"
+    user_cfg.write_text(json.dumps(_make_settings(extra_dir="/loras/user")), encoding="utf-8")
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_user_config_path", lambda: str(user_cfg))
+
+    result = _read_lora_manager_settings(str(tmp_path))
+    assert result["extra_folder_paths"]["loras"] == ["/loras/portable"]
+
+
+def test_read_settings_returns_none_when_no_files(tmp_path, monkeypatch):
+    """Returns None when neither plugin-root nor user-config settings files exist."""
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_user_config_path", lambda: str(tmp_path / "nope.json"))
+    result = _read_lora_manager_settings(str(tmp_path))
+    assert result is None
+
+
+def test_read_settings_handles_invalid_json_gracefully(tmp_path, monkeypatch):
+    """Returns None (rather than raising) on malformed JSON."""
+    (tmp_path / "settings.json").write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_user_config_path", lambda: str(tmp_path / "nope.json"))
+    result = _read_lora_manager_settings(str(tmp_path))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _get_lora_manager_lora_paths
+# ---------------------------------------------------------------------------
+
+def test_lora_paths_from_extra_folder_paths(tmp_path, monkeypatch):
+    """Returns paths from extra_folder_paths.loras."""
+    settings = {"extra_folder_paths": {"loras": ["/extra/loras"]}}
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+
+    result = _get_lora_manager_lora_paths()
+    assert result == ["/extra/loras"]
+
+
+def test_lora_paths_from_folder_paths(tmp_path, monkeypatch):
+    """Returns paths from folder_paths.loras (library-switching case)."""
+    settings = {"folder_paths": {"loras": ["/library/loras"]}}
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+
+    result = _get_lora_manager_lora_paths()
+    assert result == ["/library/loras"]
+
+
+def test_lora_paths_merges_both_keys(tmp_path, monkeypatch):
+    """Returns paths from both extra_folder_paths and folder_paths when both are present."""
+    settings = {
+        "extra_folder_paths": {"loras": ["/extra/loras"]},
+        "folder_paths": {"loras": ["/standard/loras"]},
+    }
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+
+    result = _get_lora_manager_lora_paths()
+    assert "/extra/loras" in result
+    assert "/standard/loras" in result
+    assert len(result) == 2
+
+
+def test_lora_paths_deduplicates_same_path(tmp_path, monkeypatch):
+    """A path appearing in both keys is returned only once."""
+    shared = "/shared/loras"
+    settings = {
+        "extra_folder_paths": {"loras": [shared]},
+        "folder_paths": {"loras": [shared]},
+    }
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+
+    result = _get_lora_manager_lora_paths()
+    assert result == [shared]
+
+
+def test_lora_paths_returns_empty_when_plugin_not_installed(monkeypatch):
+    """Returns [] when LoraManager is not installed (no plugin root found)."""
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: None)
+    assert _get_lora_manager_lora_paths() == []
+
+
+def test_lora_paths_returns_empty_when_no_settings(tmp_path, monkeypatch):
+    """Returns [] when plugin root exists but no settings file is found."""
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: None)
+    assert _get_lora_manager_lora_paths() == []
+
+
+def test_lora_paths_ignores_empty_string_entries(tmp_path, monkeypatch):
+    """Blank string entries in the paths list are filtered out."""
+    settings = {"extra_folder_paths": {"loras": ["   ", "", "/real/path"]}}
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+    result = _get_lora_manager_lora_paths()
+    assert result == ["/real/path"]
+
+
+def test_lora_paths_tolerates_missing_loras_key(tmp_path, monkeypatch):
+    """Settings with extra_folder_paths but no 'loras' sub-key returns []."""
+    settings = {"extra_folder_paths": {"checkpoints": ["/checkpoints"]}}
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+    assert _get_lora_manager_lora_paths() == []
+
+
+# ---------------------------------------------------------------------------
+# build_lora_index integration
+# ---------------------------------------------------------------------------
+
+def test_build_lora_index_includes_extra_lora_manager_paths(monkeypatch, tmp_path):
+    """Loras stored only in LoraManager extra paths are indexed and findable."""
+    # Standard ComfyUI path has no loras.
+    standard_dir = tmp_path / "standard_loras"
+    standard_dir.mkdir()
+
+    # LoraManager-only extra path contains add-detail-xl.safetensors.
+    extra_dir = tmp_path / "extra_loras"
+    extra_dir.mkdir()
+    lora_file = extra_dir / "add-detail-xl.safetensors"
+    lora_file.write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "loras" else [])
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_lora_paths", lambda: [str(extra_dir)])
+    _reset_index()
+
+    build_lora_index()
+    info = find_lora_info("add-detail-xl")
+    assert info is not None, "Expected add-detail-xl to be found in the extra path"
+    assert info["filename"] == "add-detail-xl.safetensors"
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(lora_file))
+
+
+def test_build_lora_index_standard_path_takes_priority_over_extra(monkeypatch, tmp_path):
+    """When the same stem exists in both standard and extra paths, the standard path wins."""
+    standard_dir = tmp_path / "standard"
+    standard_dir.mkdir()
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+
+    std_file = standard_dir / "my-lora.safetensors"
+    std_file.write_bytes(b"standard")
+    extra_file = extra_dir / "my-lora.safetensors"
+    extra_file.write_bytes(b"extra")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "loras" else [])
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_lora_paths", lambda: [str(extra_dir)])
+    _reset_index()
+
+    build_lora_index()
+    info = find_lora_info("my-lora")
+    assert info is not None
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(std_file))
+
+
+def test_build_lora_index_no_lora_manager_installed(monkeypatch, tmp_path):
+    """build_lora_index works normally when LoraManager returns no extra paths."""
+    lora_dir = tmp_path / "loras"
+    lora_dir.mkdir()
+    (lora_dir / "standard-lora.safetensors").write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(lora_dir)] if kind == "loras" else [])
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_lora_paths", lambda: [])
+    _reset_index()
+
+    build_lora_index()
+    assert find_lora_info("standard-lora") is not None
+
+
+def test_build_lora_index_deduplicates_overlapping_paths(monkeypatch, tmp_path):
+    """A path present in both ComfyUI folder_paths and LoraManager extra paths is walked only once."""
+    shared_dir = tmp_path / "shared_loras"
+    shared_dir.mkdir()
+    (shared_dir / "overlap-lora.safetensors").write_bytes(b"dummy")
+
+    walk_calls: list[str] = []
+    real_walk = os.walk
+
+    def _counting_walk(path, *args, **kwargs):
+        walk_calls.append(str(path))
+        return real_walk(path, *args, **kwargs)
+
+    monkeypatch.setattr(lora_mod.os, "walk", _counting_walk)
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(shared_dir)] if kind == "loras" else [])
+    # LoraManager also reports the same directory
+    monkeypatch.setattr(lora_mod, "_get_lora_manager_lora_paths", lambda: [str(shared_dir)])
+    _reset_index()
+
+    build_lora_index()
+
+    # File must be indexed exactly once
+    info = find_lora_info("overlap-lora")
+    assert info is not None
+    assert info["filename"] == "overlap-lora.safetensors"
+    # The directory must have been walked only once
+    assert walk_calls.count(str(shared_dir)) == 1


### PR DESCRIPTION
1. **`saveimage_unimeta/utils/lora.py`**: Added `import platform`, four new LoraManager compat helper functions (`_find_lora_manager_root`, `_get_lora_manager_user_config_path`, `_read_lora_manager_settings`, `_get_lora_manager_lora_paths`), and modified `build_lora_index()` to concatenate LoraManager extra paths with standard lora paths before walking.

2. **`tests/test_lora_manager_compat.py`**: Created new test file with 18 tests covering all helper functions and `build_lora_index` integration. Tests use monkeypatch, tmp_path, and the established pattern of resetting `lora_mod._LORA_INDEX = None` / `lora_mod._LORA_INDEX_BUILT = False`.

3. Moved the deduplication into `build_lora_index` where both sources are available, using `normcase`/`normpath` (consistent with the existing dedup in `_get_lora_manager_lora_paths`). Corrected the docstring. The new test explicitly verifies the walk count drops to 1 when the same path appears in both sources.

Meant to fix #127 