### PR TITLE
Fix tuple handling in efficiency_nodes, remove redundant call, add cache invalidation

### DIFF
--- a/saveimage_unimeta/capture.py
+++ b/saveimage_unimeta/capture.py
@@ -1809,7 +1809,7 @@ class Capture:
                     return v
             return None
 
-        t5 = _find_ci("t5 prompt") or _find_ci("t5 prompt")  # duplicate call harmless, keeps pattern
+        t5 = _find_ci("t5 prompt")  # was duplicated: or _find_ci("t5 prompt")
         clip = _find_ci("clip prompt")
 
         # Only keep T5/CLIP if BOTH exist (true dual-encoder like Flux)

--- a/saveimage_unimeta/defs/ext/efficiency_nodes.py
+++ b/saveimage_unimeta/defs/ext/efficiency_nodes.py
@@ -259,7 +259,7 @@ def _is_advanced_mode(input_data) -> bool:
     """
     try:
         return (
-            isinstance(input_data, list)
+            isinstance(input_data, list | tuple)
             and input_data
             and isinstance(input_data[0], dict)
             and isinstance(input_data[0].get("input_mode"), list)

--- a/saveimage_unimeta/defs/validators.py
+++ b/saveimage_unimeta/defs/validators.py
@@ -160,10 +160,16 @@ def _get_node_id_list(prompt, field_name):
 
 
 def is_node_connected(node_id, prompt, *args):
+    """Validation function to check if a node has any output connections.
+    Caches the result for performance, invalidating stale entries
+    when the prompt graph changes.
     """
-    Validation function to check if a node has any output connections.
-    Caches the result for performance.
-    """
+    # Invalidate cache if prompt identity changed (different graph)
+    global _CONNECTION_CACHE
+    prompt_id = id(prompt)
+    if not hasattr(is_node_connected, '_cached_prompt_id') or is_node_connected._cached_prompt_id != prompt_id:
+        _CONNECTION_CACHE.clear()
+        is_node_connected._cached_prompt_id = prompt_id
     if node_id in _CONNECTION_CACHE:
         return _CONNECTION_CACHE[node_id]
     for other_node in prompt.values():


### PR DESCRIPTION
## Summary

Three targeted bugfixes discovered during fork analysis:

### 1. Fix `isinstance(input_data, list)` → `isinstance(input_data, list | tuple)` in `efficiency_nodes.py`

This is the **same bug pattern** that was already fixed in `rgthree.py` (issue #88). The `_is_advanced_mode()` function in `efficiency_nodes.py` only checked for `list`, but ComfyUI passes `input_data` as a `tuple` in some workflows. This causes the function to return `False` prematurely, falling through to the simple mode path and producing incorrect LoRA strength metadata for Efficiency nodes.

### 2. Remove redundant `_find_ci("t5 prompt") or _find_ci("t5 prompt")` in `capture.py`

Line 1812 had `_find_ci("t5 prompt") or _find_ci("t5 prompt")` — the second call is identical to the first and will always short-circuit. Removed the redundant call.

### 3. Add cache invalidation to `is_node_connected()` in `validators.py`

The `_CONNECTION_CACHE` dict grew unboundedly across different prompts with no invalidation. Added prompt-identity-based cache clearing so stale entries from previous workflows don't persist. This uses `id(prompt)` as a lightweight identity check — when the prompt object changes, the cache is cleared.

## Testing

- All efficiency tests pass (45 test_efficiency_helpers + 9 test_efficiency_loader_lora_stack + 23 test_efficiency_lora_stack)
- Python syntax validation passes for all three modified files
- Changes are backward-compatible with no API changes

## Related Issues

- Follows the same fix pattern as issue #88 (rgthree tuple handling)