### PR TITLE
Feat/lora manager extra paths all model types

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ Authoritative onboarding for `ComfyUI_SaveImageWithMetaDataUniversal`. This repo
 
 ## Runtime Integration & Environment Flags
 - Runs embedded in ComfyUI; expect access to `folder_paths`, sampler nodes, and numerous other `comfy.` imports, and PIL. When unit testing, `saveimage_unimeta/piexif_alias.py` and `hook.py` provide safe stubs—only extend the stub surface actually required.
-- Runtime feature flags (read at execution time, no restart needed) include: `METADATA_TEST_MODE`, `METADATA_NO_HASH_DETAIL`, `METADATA_NO_LORA_SUMMARY`, `METADATA_FORCE_REHASH`, `METADATA_HASH_LOG_MODE`, `METADATA_HASH_LOG_PROPAGATE`, `METADATA_DUMP_LORA_INDEX`, `METADATA_ENABLE_TEST_NODES`, `METADATA_DEBUG_PROMPTS`. UI checkbox `include_lora_summary` overrides the env flag.
+- Runtime feature flags (read at execution time, no restart needed) include: `METADATA_TEST_MODE`, `METADATA_NO_HASH_DETAIL`, `METADATA_NO_LORA_SUMMARY`, `METADATA_FORCE_REHASH`, `METADATA_HASH_LOG_MODE`, `METADATA_HASH_LOG_PROPAGATE`, `METADATA_DUMP_LORA_INDEX`, `METADATA_DUMP_CHECKPOINT_INDEX`, `METADATA_DUMP_UNET_INDEX`, `METADATA_ENABLE_TEST_NODES`, `METADATA_DEBUG_PROMPTS`. UI checkbox `include_lora_summary` overrides the env flag.
 - JPEG/env documentation source of truth: `docs/JPEG_METADATA_FALLBACK.md`, `docs/WORKFLOW_COMPRESSION_DESIGN.md`, `docs/FUTURE_AND_PROTOTYPES.md`. Update both docs + this file when behavior changes.
 
 ## Build, Lint, Test (validated locally and mirrored by CI)
@@ -57,7 +57,7 @@ Authoritative onboarding for `ComfyUI_SaveImageWithMetaDataUniversal`. This repo
 - **Docs**: `docs/JPEG_METADATA_FALLBACK.md`, `docs/MIGRATIONS.md`, `docs/V3_SCHEMA_MIGRATION.md` (for future migration to V3; no specific timeline for implementing this yet), `docs/WAN22_SUPPORT.md`, `docs/FUTURE_AND_PROTOTYPES.md` (historical context). Keep them synchronized with behavior changes.
 - **Workflow samples**: `example_workflows/*.json` showcase Force Include, extra metadata, LoRA stacks, WAN/FLUX flows. Use them to reproduce bugs quickly.
 - **Testing aids**: `saveimage_unimeta/nodes/testing_stubs.py` exposes lightweight sampler nodes when `METADATA_ENABLE_TEST_NODES=1`; `tests/` contains stub fixtures demonstrating how to patch ComfyUI APIs.
-- **Troubleshooting tips**: enable `METADATA_DEBUG_PROMPTS=1` to log prompt aliasing, drop `max_jpeg_exif_kb` to 8 to hit fallback paths, set `METADATA_NO_HASH_DETAIL=1` or `METADATA_NO_LORA_SUMMARY=1` to verify UI overrides. Hash mismatches? delete `.sha256` sidecars or set `METADATA_FORCE_REHASH=1`.
+- **Troubleshooting tips**: enable `METADATA_DEBUG_PROMPTS=1` to log prompt aliasing, drop `max_jpeg_exif_kb` to 8 to hit fallback paths, set `METADATA_NO_HASH_DETAIL=1` or `METADATA_NO_LORA_SUMMARY=1` to verify UI overrides, and use `METADATA_DUMP_LORA_INDEX`, `METADATA_DUMP_CHECKPOINT_INDEX`, or `METADATA_DUMP_UNET_INDEX` to dump the first-built indexes for diagnostics. Hash mismatches? delete `.sha256` sidecars or set `METADATA_FORCE_REHASH=1`.
 
 ## Working Style & Search Discipline
 - Start from this file: it summarizes architecture, commands, and directory hotspots—search the codebase only if something here is missing or inaccurate. When in doubt, inspect `saveimage_unimeta/` modules referenced above before global greps.

--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ docs/releases/*
 /PR_DRAFT_*.md
 docs/releases/RELEASE_NOTES_*1.2*.md
 docs/releases/PR_DRAFT_*1.2*.md
+
+# Claude
+.claude/

--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ Deferred and exploratory concepts are documented in:
 | `METADATA_HASH_LOG_PROPAGATE` | `0` to suppress propagation to root logger (keep logs local); `1` (default) to propagate. |
 | `METADATA_FORCE_REHASH` | When set to `1`, recomputes hashes ignoring existing `.sha256` sidecars (diagnostics / mismatch recovery). |
 | `METADATA_DUMP_LORA_INDEX` | When set: dump LoRA index JSON after first build. Value `1` → `_lora_index_dump.json` in CWD; otherwise use as output path. |
+| `METADATA_DUMP_CHECKPOINT_INDEX` | When set: dump checkpoint index JSON after first build. Value `1` → `_checkpoint_index_dump.json` in CWD; otherwise trim whitespace and use the value as the output path. |
+| `METADATA_DUMP_UNET_INDEX` | When set: dump UNet index JSON after first build. Value `1` → `_unet_index_dump.json` in CWD; otherwise trim whitespace and use the value as the output path. |
 | `METADATA_ENABLE_TEST_NODES` | Enable lightweight stub nodes (e.g., `MetadataTestSampler`) for metadata-only workflows without loading real models. |
 
 Additional Support:
@@ -479,4 +481,3 @@ For extended sampler selection details and advanced capture behavior, refer to t
 </details>
 
 日本語版READMEは[こちら](README.jp.md)。
-

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Deferred and exploratory concepts are documented in:
 | `METADATA_HASH_LOG_MODE` | Hash logging mode: `none` (default), `filename`, `path`, `detailed`, `debug` (includes candidate lists + full hash timing). |
 | `METADATA_HASH_LOG_PROPAGATE` | `0` to suppress propagation to root logger (keep logs local); `1` (default) to propagate. |
 | `METADATA_FORCE_REHASH` | When set to `1`, recomputes hashes ignoring existing `.sha256` sidecars (diagnostics / mismatch recovery). |
-| `METADATA_DUMP_LORA_INDEX` | When set: dump LoRA index JSON after first build. Value `1` → `_lora_index_dump.json` in CWD; otherwise use as output path. |
+| `METADATA_DUMP_LORA_INDEX` | When set: dump LoRA index JSON after first build. Value `1` → `_lora_index_dump.json` in CWD; otherwise trim whitespace and use the value as the output path. |
 | `METADATA_DUMP_CHECKPOINT_INDEX` | When set: dump checkpoint index JSON after first build. Value `1` → `_checkpoint_index_dump.json` in CWD; otherwise trim whitespace and use the value as the output path. |
 | `METADATA_DUMP_UNET_INDEX` | When set: dump UNet index JSON after first build. Value `1` → `_unet_index_dump.json` in CWD; otherwise trim whitespace and use the value as the output path. |
 | `METADATA_ENABLE_TEST_NODES` | Enable lightweight stub nodes (e.g., `MetadataTestSampler`) for metadata-only workflows without loading real models. |

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -100,8 +100,17 @@ for _n in _ALT_NAMES:
         _sys.modules[_n] = _SELF
 
 
-def _embedding_path_test_mode_enabled() -> bool:
-    """Return True when embedding path resolution should stay deterministic in tests."""
+def _lora_manager_discovery_disabled_in_tests() -> bool:
+    """Return True when LoraManager settings discovery should be skipped for tests.
+
+    Gates the cached ``_get_lm_*_dirs`` helpers (embeddings, checkpoints,
+    UNet) so that test outcomes do not depend on a developer's local
+    LoraManager installation. Returns True when either ``PYTEST_CURRENT_TEST``
+    is set or ``METADATA_TEST_MODE`` is truthy. ``METADATA_TEST_MODE`` is the
+    project-wide opt-in test gate also used elsewhere (e.g. ``capture.py``)
+    to switch behavior under tests, so honoring it here is consistent with
+    the rest of the codebase.
+    """
     if os.environ.get("PYTEST_CURRENT_TEST"):
         return True
     return os.environ.get("METADATA_TEST_MODE", "").strip().lower() in _TEST_MODE_TRUTHY
@@ -115,7 +124,7 @@ def _get_lm_embedding_dirs() -> list[str]:
     hashing tests do not depend on a real ComfyUI custom_nodes installation.
     """
     global _LM_EMBEDDING_DIRS_CACHE
-    if _embedding_path_test_mode_enabled():
+    if _lora_manager_discovery_disabled_in_tests():
         return []
     if _LM_EMBEDDING_DIRS_CACHE is None:
         _LM_EMBEDDING_DIRS_CACHE = get_lora_manager_paths("embeddings")
@@ -132,7 +141,7 @@ def _get_lm_checkpoint_dirs() -> list[str]:
     explicitly.
     """
     global _LM_CKPT_DIRS_CACHE
-    if _embedding_path_test_mode_enabled():
+    if _lora_manager_discovery_disabled_in_tests():
         return []
     if _LM_CKPT_DIRS_CACHE is None:
         _LM_CKPT_DIRS_CACHE = get_lora_manager_paths("checkpoints")
@@ -149,7 +158,7 @@ def _get_lm_unet_dirs() -> list[str]:
     explicitly.
     """
     global _LM_UNET_DIRS_CACHE
-    if _embedding_path_test_mode_enabled():
+    if _lora_manager_discovery_disabled_in_tests():
         return []
     if _LM_UNET_DIRS_CACHE is None:
         _LM_UNET_DIRS_CACHE = get_lora_manager_paths("unet")

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -81,6 +81,10 @@ _LM_EMBEDDING_DIRS_CACHE: list[str] | None = None
 # circuits and avoids triggering a full directory walk via
 # `build_checkpoint_index` / `build_unet_index` whose contents would only mirror
 # what `try_resolve_artifact` already probed in the standard `folder_paths`.
+# Test mode (``PYTEST_CURRENT_TEST`` or ``METADATA_TEST_MODE``) also forces
+# these helpers to return ``[]`` so test outcomes do not depend on a developer's
+# local LoraManager installation; tests requiring non-empty paths should
+# monkeypatch the helpers explicitly.
 _LM_CKPT_DIRS_CACHE: list[str] | None = None
 _LM_UNET_DIRS_CACHE: list[str] | None = None
 _TEST_MODE_TRUTHY = {"1", "true", "yes", "on"}
@@ -119,28 +123,34 @@ def _get_lm_embedding_dirs() -> list[str]:
 
 
 def _get_lm_checkpoint_dirs() -> list[str]:
-    """Return cached LoraManager checkpoint paths.
+    """Return cached LoraManager checkpoint paths unless test mode disables settings reads.
 
-    Unlike :func:`_get_lm_embedding_dirs`, this helper does not gate on test
-    mode. Tests that exercise ``_ckpt_index_resolver`` directly should
-    monkeypatch this helper to return a non-empty list. In environments
-    without LoraManager installed (including CI) the underlying
-    :func:`get_lora_manager_paths` returns an empty list, which lets the
-    resolver short-circuit naturally.
+    Mirrors :func:`_get_lm_embedding_dirs`: pytest runs (and
+    ``METADATA_TEST_MODE``) skip LoraManager settings discovery so test
+    outcomes do not depend on a developer's local LoraManager installation.
+    Tests that need non-empty checkpoint paths should monkeypatch this helper
+    explicitly.
     """
     global _LM_CKPT_DIRS_CACHE
+    if _embedding_path_test_mode_enabled():
+        return []
     if _LM_CKPT_DIRS_CACHE is None:
         _LM_CKPT_DIRS_CACHE = get_lora_manager_paths("checkpoints")
     return _LM_CKPT_DIRS_CACHE
 
 
 def _get_lm_unet_dirs() -> list[str]:
-    """Return cached LoraManager UNet paths.
+    """Return cached LoraManager UNet paths unless test mode disables settings reads.
 
-    See :func:`_get_lm_checkpoint_dirs` for rationale on why this does not
-    apply the embedding-style test-mode gate.
+    Mirrors :func:`_get_lm_embedding_dirs`: pytest runs (and
+    ``METADATA_TEST_MODE``) skip LoraManager settings discovery so test
+    outcomes do not depend on a developer's local LoraManager installation.
+    Tests that need non-empty UNet paths should monkeypatch this helper
+    explicitly.
     """
     global _LM_UNET_DIRS_CACHE
+    if _embedding_path_test_mode_enabled():
+        return []
     if _LM_UNET_DIRS_CACHE is None:
         _LM_UNET_DIRS_CACHE = get_lora_manager_paths("unet")
     return _LM_UNET_DIRS_CACHE

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -296,9 +296,6 @@ def _ckpt_name_to_path(name_like: Any) -> tuple[str, str | None]:
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_checkpoint_info(key if key else basename)
-        if not info and basename != stem:
-            raw_key, _ = os.path.splitext(stem)
-            info = find_checkpoint_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     res = try_resolve_artifact("checkpoints", name_like, post_resolvers=[_ckpt_index_resolver])
@@ -729,9 +726,6 @@ def calc_unet_hash(model_name: Any, input_data: list) -> str:
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_unet_info(key if key else basename)
-        if not info and basename != stem:
-            raw_key, _ = os.path.splitext(stem)
-            info = find_unet_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     # Unified attempt

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -293,8 +293,12 @@ _EMBEDDING_TRAILING_STRIP = " ,，。.;；:：!?！？、·"
 def _ckpt_name_to_path(name_like: Any) -> tuple[str, str | None]:
     """Unified resolver wrapper for backward compatibility."""
     def _ckpt_index_resolver(stem: str) -> str | None:
-        key, _ = os.path.splitext(stem)
-        info = find_checkpoint_info(key if key else stem)
+        basename = os.path.basename(stem)
+        key, _ = os.path.splitext(basename)
+        info = find_checkpoint_info(key if key else basename)
+        if not info and basename != stem:
+            raw_key, _ = os.path.splitext(stem)
+            info = find_checkpoint_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     res = try_resolve_artifact("checkpoints", name_like, post_resolvers=[_ckpt_index_resolver])
@@ -722,8 +726,12 @@ def calc_unet_hash(model_name: Any, input_data: list) -> str:
     """
 
     def _unet_index_resolver(stem: str) -> str | None:
-        key, _ = os.path.splitext(stem)
-        info = find_unet_info(key if key else stem)
+        basename = os.path.basename(stem)
+        key, _ = os.path.splitext(basename)
+        info = find_unet_info(key if key else basename)
+        if not info and basename != stem:
+            raw_key, _ = os.path.splitext(stem)
+            info = find_unet_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     # Unified attempt

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -75,6 +75,14 @@ _BANNER_PRINTED = False
 
 # Session-lifetime cache for LoraManager embedding paths (avoids file I/O on every image)
 _LM_EMBEDDING_DIRS_CACHE: list[str] | None = None
+# Session-lifetime caches for LoraManager checkpoint/UNet paths. These gate the
+# basename-only index resolvers in `_ckpt_name_to_path` / `calc_unet_hash`: when
+# LoraManager registers no extra dirs for the model type, the resolver short-
+# circuits and avoids triggering a full directory walk via
+# `build_checkpoint_index` / `build_unet_index` whose contents would only mirror
+# what `try_resolve_artifact` already probed in the standard `folder_paths`.
+_LM_CKPT_DIRS_CACHE: list[str] | None = None
+_LM_UNET_DIRS_CACHE: list[str] | None = None
 _TEST_MODE_TRUTHY = {"1", "true", "yes", "on"}
 
 # Prevent duplicate module instances under different package names (runtime vs tests)
@@ -108,6 +116,34 @@ def _get_lm_embedding_dirs() -> list[str]:
     if _LM_EMBEDDING_DIRS_CACHE is None:
         _LM_EMBEDDING_DIRS_CACHE = get_lora_manager_paths("embeddings")
     return _LM_EMBEDDING_DIRS_CACHE
+
+
+def _get_lm_checkpoint_dirs() -> list[str]:
+    """Return cached LoraManager checkpoint paths.
+
+    Unlike :func:`_get_lm_embedding_dirs`, this helper does not gate on test
+    mode. Tests that exercise ``_ckpt_index_resolver`` directly should
+    monkeypatch this helper to return a non-empty list. In environments
+    without LoraManager installed (including CI) the underlying
+    :func:`get_lora_manager_paths` returns an empty list, which lets the
+    resolver short-circuit naturally.
+    """
+    global _LM_CKPT_DIRS_CACHE
+    if _LM_CKPT_DIRS_CACHE is None:
+        _LM_CKPT_DIRS_CACHE = get_lora_manager_paths("checkpoints")
+    return _LM_CKPT_DIRS_CACHE
+
+
+def _get_lm_unet_dirs() -> list[str]:
+    """Return cached LoraManager UNet paths.
+
+    See :func:`_get_lm_checkpoint_dirs` for rationale on why this does not
+    apply the embedding-style test-mode gate.
+    """
+    global _LM_UNET_DIRS_CACHE
+    if _LM_UNET_DIRS_CACHE is None:
+        _LM_UNET_DIRS_CACHE = get_lora_manager_paths("unet")
+    return _LM_UNET_DIRS_CACHE
 
 
 def set_hash_log_mode(mode: str):
@@ -308,6 +344,12 @@ _EMBEDDING_TRAILING_STRIP = " ,，。.;；:：!?！？、·"
 def _ckpt_name_to_path(name_like: Any) -> tuple[str, str | None]:
     """Unified resolver wrapper for backward compatibility."""
     def _ckpt_index_resolver(stem: str) -> str | None:
+        # `try_resolve_artifact` already exhausted standard `folder_paths`
+        # checkpoint dirs (with extension probing). The basename-only index
+        # only adds value when LoraManager registers extra dirs out-of-tree;
+        # otherwise skip the (potentially expensive) full directory walk.
+        if not _get_lm_checkpoint_dirs():
+            return None
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_checkpoint_info(key if key else basename)
@@ -738,6 +780,10 @@ def calc_unet_hash(model_name: Any, input_data: list) -> str:
     """
 
     def _unet_index_resolver(stem: str) -> str | None:
+        # See `_ckpt_index_resolver` for rationale: skip the index walk when
+        # LoraManager has not registered extra UNet dirs.
+        if not _get_lm_unet_dirs():
+            return None
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_unet_info(key if key else basename)

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -75,6 +75,7 @@ _BANNER_PRINTED = False
 
 # Session-lifetime cache for LoraManager embedding paths (avoids file I/O on every image)
 _LM_EMBEDDING_DIRS_CACHE: list[str] | None = None
+_TEST_MODE_TRUTHY = {"1", "true", "yes", "on"}
 
 # Prevent duplicate module instances under different package names (runtime vs tests)
 _SELF = _sys.modules.get(__name__)
@@ -87,9 +88,23 @@ for _n in _ALT_NAMES:
         _sys.modules[_n] = _SELF
 
 
+def _embedding_path_test_mode_enabled() -> bool:
+    """Return True when embedding path resolution should stay deterministic in tests."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return True
+    return os.environ.get("METADATA_TEST_MODE", "").strip().lower() in _TEST_MODE_TRUTHY
+
+
 def _get_lm_embedding_dirs() -> list[str]:
-    """Return LoraManager embedding paths, cached for the session lifetime."""
+    """Return cached LoraManager embedding paths unless test mode disables settings reads.
+
+    The embedding formatter path skips LoraManager settings discovery while
+    ``METADATA_TEST_MODE`` or ``PYTEST_CURRENT_TEST`` is active so prompt
+    hashing tests do not depend on a real ComfyUI custom_nodes installation.
+    """
     global _LM_EMBEDDING_DIRS_CACHE
+    if _embedding_path_test_mode_enabled():
+        return []
     if _LM_EMBEDDING_DIRS_CACHE is None:
         _LM_EMBEDDING_DIRS_CACHE = get_lora_manager_paths("embeddings")
     return _LM_EMBEDDING_DIRS_CACHE

--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -51,7 +51,7 @@ except (ImportError, ModuleNotFoundError):  # noqa: BLE001 - provide minimal stu
 
 
 from ..utils.embedding import get_embedding_file_path
-from ..utils.lora import find_lora_info
+from ..utils.lora import find_lora_info, find_checkpoint_info, find_unet_info, get_lora_manager_paths
 from ..utils.pathresolve import (
     try_resolve_artifact,
     sanitize_candidate,
@@ -73,6 +73,9 @@ _LOGGER_INITIALIZED = False
 _HANDLER_TAG = "__hash_logger_handler__"
 _BANNER_PRINTED = False
 
+# Session-lifetime cache for LoraManager embedding paths (avoids file I/O on every image)
+_LM_EMBEDDING_DIRS_CACHE: list[str] | None = None
+
 # Prevent duplicate module instances under different package names (runtime vs tests)
 _SELF = _sys.modules.get(__name__)
 _ALT_NAMES = [
@@ -82,6 +85,14 @@ _ALT_NAMES = [
 for _n in _ALT_NAMES:
     if _n not in _sys.modules and _SELF is not None:
         _sys.modules[_n] = _SELF
+
+
+def _get_lm_embedding_dirs() -> list[str]:
+    """Return LoraManager embedding paths, cached for the session lifetime."""
+    global _LM_EMBEDDING_DIRS_CACHE
+    if _LM_EMBEDDING_DIRS_CACHE is None:
+        _LM_EMBEDDING_DIRS_CACHE = get_lora_manager_paths("embeddings")
+    return _LM_EMBEDDING_DIRS_CACHE
 
 
 def set_hash_log_mode(mode: str):
@@ -281,7 +292,12 @@ _EMBEDDING_TRAILING_STRIP = " ,，。.;；:：!?！？、·"
 
 def _ckpt_name_to_path(name_like: Any) -> tuple[str, str | None]:
     """Unified resolver wrapper for backward compatibility."""
-    res = try_resolve_artifact("checkpoints", name_like)
+    def _ckpt_index_resolver(stem: str) -> str | None:
+        key, _ = os.path.splitext(stem)
+        info = find_checkpoint_info(key if key else stem)
+        return info["abspath"] if info else None
+
+    res = try_resolve_artifact("checkpoints", name_like, post_resolvers=[_ckpt_index_resolver])
     if res.full_path:
         return res.display_name, res.full_path
     # Legacy fallback (ensures test patches to this module's folder_paths still work)
@@ -705,8 +721,13 @@ def calc_unet_hash(model_name: Any, input_data: list) -> str:
         10-character truncated hex hash or 'N/A'.
     """
 
+    def _unet_index_resolver(stem: str) -> str | None:
+        key, _ = os.path.splitext(stem)
+        info = find_unet_info(key if key else stem)
+        return info["abspath"] if info else None
+
     # Unified attempt
-    res = try_resolve_artifact("unet", model_name)
+    res = try_resolve_artifact("unet", model_name, post_resolvers=[_unet_index_resolver])
     filename = res.full_path
     if not filename and isinstance(model_name, str):  # legacy fallback for tests
         original = model_name
@@ -892,6 +913,7 @@ def _extract_embedding_candidates(text, input_data):
         parsed_weights = [(text, 1.0)]
 
     allow_resolution = clip is not None and bool(embedding_dir)
+    lm_embedding_dirs = _get_lm_embedding_dirs()
 
     embedding_names: list[str] = []
     resolved_paths: list[str | None] = []
@@ -934,10 +956,22 @@ def _extract_embedding_candidates(text, input_data):
                 resolved_path = None
                 if allow_resolution:
                     try:
-                        resolved_path = get_embedding_file_path(sanitized, clip)
+                        resolved_path = get_embedding_file_path(
+                            sanitized, clip, extra_dirs=lm_embedding_dirs or None
+                        )
                     except (OSError, TypeError, ValueError) as err:
                         logger.debug(
                             "[Metadata Lib] Embedding '%s' resolution error: %r",
+                            display_name,
+                            err,
+                        )
+                        resolved_path = None
+                elif lm_embedding_dirs:
+                    try:
+                        resolved_path = get_embedding_file_path(sanitized, None, extra_dirs=lm_embedding_dirs)
+                    except (OSError, TypeError, ValueError) as err:
+                        logger.debug(
+                            "[Metadata Lib] Embedding '%s' LoraManager resolution error: %r",
                             display_name,
                             err,
                         )

--- a/saveimage_unimeta/utils/embedding.py
+++ b/saveimage_unimeta/utils/embedding.py
@@ -21,12 +21,15 @@ except Exception:  # noqa: BLE001 - test fallback
 __all__ = ["get_embedding_file_path"]
 
 
-def get_embedding_file_path(embedding_name: str, clip: object) -> str | None:
+def get_embedding_file_path(embedding_name: str, clip: object | None, *, extra_dirs: list[str] | None = None) -> str | None:
     """Resolve an embedding filename to an absolute path if it exists.
 
     The lookup expands the `clip.embedding_directory` attribute (string or sequence
     of strings) using ComfyUI's `expand_directory_list`, then searches each
     directory for the provided base name with or without a known extension.
+
+    When `clip` is None and `extra_dirs` is provided, only extra_dirs are searched.
+    When `clip` is None and no `extra_dirs` provided, returns None immediately.
 
     Search order per directory:
       1. Exact `embedding_name` as‑is (allows explicit extension callers)
@@ -41,9 +44,12 @@ def get_embedding_file_path(embedding_name: str, clip: object) -> str | None:
             extension). Should NOT contain parent references intended to escape
             search roots.
         clip: Object with an `embedding_directory` attribute (string or
-            iterable of strings). This mirrors the structure on ComfyUI CLIP
-            objects. Attribute absence or emptiness raises `ValueError` for
-            clearer upstream diagnostics.
+            iterable of strings), or None. When clip is None and no extra_dirs
+            provided, returns None immediately. Attribute absence or emptiness
+            raises `ValueError` for clearer upstream diagnostics.
+        extra_dirs: Optional list of additional absolute directory paths to
+            search after clip-derived dirs. `ValueError` from clip-side
+            validation fires before extra_dirs is searched.
 
     Returns:
         Absolute path to the first matching embedding file, or `None` if no
@@ -53,33 +59,46 @@ def get_embedding_file_path(embedding_name: str, clip: object) -> str | None:
         ValueError: If the embedding directory attribute is missing/empty, the
             expansion yields no valid directories, or expansion fails.
     """
-    embedding_directory = getattr(clip, "embedding_directory", None)
-    if not embedding_directory:
-        raise ValueError(
-            "The 'embedding_directory' attribute in the clip object is None or empty."  # noqa: E501
-        )
+    # Fast path: nothing to search
+    if clip is None and not extra_dirs:
+        return None
 
-    if isinstance(embedding_directory, str):
-        embedding_dirs: Sequence[str] = [embedding_directory]
-    elif isinstance(embedding_directory, list | tuple | set):
-        embedding_dirs = [str(p) for p in embedding_directory]
-    else:  # Fallback: treat single unknown object as string repr
-        embedding_dirs = [str(embedding_directory)]
+    dirs_to_search: list[str] = []
 
-    try:
-        expanded: list[str] = expand_directory_list(list(embedding_dirs))
-    except (OSError, TypeError, ValueError) as e:  # Narrow common failures
-        raise ValueError(f"Error expanding directory list: {e}") from e
-    except Exception as e:  # pragma: no cover - defensive catch
-        raise ValueError(f"Unexpected error expanding directory list: {e}") from e
+    if clip is not None:
+        embedding_directory = getattr(clip, "embedding_directory", None)
+        if not embedding_directory:
+            raise ValueError(
+                "The 'embedding_directory' attribute in the clip object is None or empty."
+            )
 
-    if not expanded:
-        raise ValueError("No valid directories found after expansion.")
+        if isinstance(embedding_directory, str):
+            embedding_dirs: Sequence[str] = [embedding_directory]
+        elif isinstance(embedding_directory, list | tuple | set):
+            embedding_dirs = [str(p) for p in embedding_directory]
+        else:
+            embedding_dirs = [str(embedding_directory)]
+
+        try:
+            expanded: list[str] = expand_directory_list(list(embedding_dirs))
+        except (OSError, TypeError, ValueError) as e:
+            raise ValueError(f"Error expanding directory list: {e}") from e
+        except Exception as e:  # pragma: no cover - defensive catch
+            raise ValueError(f"Unexpected error expanding directory list: {e}") from e
+
+        if not expanded:
+            raise ValueError("No valid directories found after expansion.")
+
+        dirs_to_search = expanded
+
+    # Append extra dirs (from e.g. LoraManager) after clip-derived dirs
+    if extra_dirs:
+        dirs_to_search = dirs_to_search + [d for d in extra_dirs if isinstance(d, str) and d.strip()]
 
     valid_file: str | None = None
     extensions = [".safetensors", ".pt", ".bin"]
 
-    for embed_dir in expanded:
+    for embed_dir in dirs_to_search:
         embed_dir_abs = os.path.abspath(embed_dir)
         if not os.path.isdir(embed_dir_abs):
             continue
@@ -89,13 +108,13 @@ def get_embedding_file_path(embedding_name: str, clip: object) -> str | None:
             if os.path.commonpath([embed_dir_abs, embed_path]) != embed_dir_abs:
                 # Path attempted to escape search root – ignore
                 continue
-        except (OSError, ValueError):  # Invalid path comparison edge cases
+        except (OSError, ValueError):
             continue
 
         # Direct file match
         if os.path.isfile(embed_path):
             valid_file = embed_path
-        else:  # Try with extensions
+        else:
             for ext in extensions:
                 candidate_path = embed_path + ext
                 if os.path.isfile(candidate_path):

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -6,6 +6,7 @@ used in prompts (e.g., `<lora:name:strength>`). This allows for the efficient
 extraction and resolution of LoRA metadata from a ComfyUI workflow.
 Includes:
 * One-time index mapping LoRA base names to on-disk locations (for fast lookup).
+* One-time index mapping checkpoint/UNet base names to on-disk locations.
 """
 
 import logging
@@ -21,6 +22,10 @@ import json
 # This index will be built once and reused to speed up all subsequent LoRA lookups.
 _LORA_INDEX: dict[str, dict[str, str]] | None = None
 _LORA_INDEX_BUILT: bool = False
+_CHECKPOINT_INDEX: dict[str, dict[str, str]] | None = None
+_CHECKPOINT_INDEX_BUILT: bool = False
+_UNET_INDEX: dict[str, dict[str, str]] | None = None
+_UNET_INDEX_BUILT: bool = False
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -140,15 +145,21 @@ def _read_lora_manager_settings(plugin_root: str) -> dict | None:
     return None
 
 
-def _get_lora_manager_lora_paths() -> list[str]:
-    """Return lora directory paths from LoraManager's settings.json.
+def get_lora_manager_paths(model_type: str) -> list[str]:
+    """Return extra model directory paths from LoraManager's settings.json.
 
-    Reads from both ``extra_folder_paths.loras`` (paths exclusive to LoraManager)
-    and ``folder_paths.loras`` (which may differ from ComfyUI's paths when the
-    user has activated a non-default LoraManager library).
+    Reads from both ``extra_folder_paths.<model_type>`` and
+    ``folder_paths.<model_type>`` keys in the settings file.
 
-    Returns an empty list if LoraManager is not installed, has no settings file,
-    or has no additional lora paths configured.
+    Args:
+        model_type: The model type key used in LoraManager's settings
+            (e.g. ``"loras"``, ``"checkpoints"``, ``"unet"``,
+            ``"embeddings"``).
+
+    Returns:
+        Deduplicated list of absolute path strings, or an empty list if
+        LoraManager is not installed, has no settings file, or has no
+        paths for the requested type.
     """
     plugin_root = _find_lora_manager_root()
     if not plugin_root:
@@ -163,7 +174,7 @@ def _get_lora_manager_lora_paths() -> list[str]:
         section = settings.get(key)
         if not isinstance(section, dict):
             continue
-        for p in section.get("loras", []):
+        for p in section.get(model_type, []):
             if isinstance(p, str) and p.strip():
                 paths.append(p.strip())
 
@@ -176,6 +187,19 @@ def _get_lora_manager_lora_paths() -> list[str]:
             seen.add(norm)
             unique.append(p)
     return unique
+
+
+def _get_lora_manager_lora_paths() -> list[str]:
+    """Return lora directory paths from LoraManager's settings.json.
+
+    Reads from both ``extra_folder_paths.loras`` (paths exclusive to LoraManager)
+    and ``folder_paths.loras`` (which may differ from ComfyUI's paths when the
+    user has activated a non-default LoraManager library).
+
+    Returns an empty list if LoraManager is not installed, has no settings file,
+    or has no additional lora paths configured.
+    """
+    return get_lora_manager_paths("loras")
 
 
 def build_lora_index() -> None:
@@ -290,6 +314,200 @@ def find_lora_info(base_name: str) -> dict[str, str] | None:
     return _LORA_INDEX.get(base_name)
 
 
+# ---------------------------------------------------------------------------
+# TODO: LoraManager currently only populates extra_folder_paths.loras in
+#   practice, so build_checkpoint_index and build_unet_index will typically
+#   return no extra paths. These functions are implemented for forward
+#   compatibility when LoraManager expands its extra-paths support.
+# ---------------------------------------------------------------------------
+
+
+def build_checkpoint_index() -> None:
+    """Populate (idempotently) the in-memory checkpoint file index.
+
+    Mirrors :func:`build_lora_index` for checkpoint files.  Scans
+    ``folder_paths.get_folder_paths('checkpoints')`` plus any extra
+    paths from LoraManager's settings (forward-compat — not currently
+    populated by LoraManager).
+
+    Side Effects:
+        Mutates module-level caches ``_CHECKPOINT_INDEX`` and
+        ``_CHECKPOINT_INDEX_BUILT``.
+    """
+    global _CHECKPOINT_INDEX, _CHECKPOINT_INDEX_BUILT
+    if _CHECKPOINT_INDEX_BUILT:
+        return
+
+    logger.info("[Metadata Lib] Building checkpoint file index for the first time...")
+    _CHECKPOINT_INDEX = {}
+    ckpt_paths = folder_paths.get_folder_paths("checkpoints")
+    extensions = list(SUPPORTED_MODEL_EXTENSIONS)
+
+    extra_lm_paths = get_lora_manager_paths("checkpoints")
+
+    seen_dirs: set[str] = set()
+    all_ckpt_dirs: list[str] = []
+
+    for d in ckpt_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_ckpt_dirs.append(d)
+
+    extra_unique_dirs: list[str] = []
+    for d in extra_lm_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_ckpt_dirs.append(d)
+            extra_unique_dirs.append(d)
+
+    if extra_lm_paths:
+        if extra_unique_dirs:
+            logger.info(
+                "[Metadata Lib] Found %d extra checkpoint path(s) from LoraManager settings.",
+                len(extra_unique_dirs),
+            )
+        else:
+            logger.info(
+                "[Metadata Lib] LoraManager settings.json defined checkpoint paths,"
+                " but all are already covered by existing checkpoint directories.",
+            )
+
+    for ckpt_dir in all_ckpt_dirs:
+        for root, _, files in os.walk(ckpt_dir):
+            for file in files:
+                file_base, file_ext = os.path.splitext(file)
+                if file_ext in extensions and file_base not in _CHECKPOINT_INDEX:
+                    _CHECKPOINT_INDEX[file_base] = {
+                        "filename": file,
+                        "abspath": os.path.join(root, file),
+                    }
+
+    _CHECKPOINT_INDEX_BUILT = True
+    logger.info("[Metadata Lib] Checkpoint index built with %d entries.", len(_CHECKPOINT_INDEX))
+    try:
+        if dump_env := os.environ.get("METADATA_DUMP_CHECKPOINT_INDEX"):
+            dump_path = dump_env.strip()
+            if dump_path.lower() == "1":
+                dump_path = os.path.join(os.getcwd(), "_checkpoint_index_dump.json")
+            with open(dump_path, "w", encoding="utf-8") as f:
+                json.dump(_CHECKPOINT_INDEX, f, indent=2, sort_keys=True)
+            logger.info("[Metadata Lib] Checkpoint index dumped to %s", dump_path)
+    except Exception as e:  # pragma: no cover - diagnostic optional
+        logger.debug("[Metadata Lib] Failed dumping checkpoint index: %r", e)
+
+
+def find_checkpoint_info(base_name: str) -> dict[str, str] | None:
+    """Find the indexed information for a checkpoint by its base name.
+
+    Args:
+        base_name (str): The base name of the checkpoint file (without the
+            extension).
+
+    Returns:
+        dict[str, str] | None: A dictionary containing the ``filename`` and
+            ``abspath`` of the checkpoint, or None if not found.
+    """
+    build_checkpoint_index()
+    if _CHECKPOINT_INDEX is None:
+        return None
+    return _CHECKPOINT_INDEX.get(base_name)
+
+
+def build_unet_index() -> None:
+    """Populate (idempotently) the in-memory UNet file index.
+
+    Mirrors :func:`build_lora_index` for UNet files.  Scans
+    ``folder_paths.get_folder_paths('unet')`` plus any extra paths from
+    LoraManager's settings (forward-compat — not currently populated by
+    LoraManager).
+
+    Side Effects:
+        Mutates module-level caches ``_UNET_INDEX`` and
+        ``_UNET_INDEX_BUILT``.
+    """
+    global _UNET_INDEX, _UNET_INDEX_BUILT
+    if _UNET_INDEX_BUILT:
+        return
+
+    logger.info("[Metadata Lib] Building UNet file index for the first time...")
+    _UNET_INDEX = {}
+    unet_paths = folder_paths.get_folder_paths("unet")
+    extensions = list(SUPPORTED_MODEL_EXTENSIONS)
+
+    extra_lm_paths = get_lora_manager_paths("unet")
+
+    seen_dirs: set[str] = set()
+    all_unet_dirs: list[str] = []
+
+    for d in unet_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_unet_dirs.append(d)
+
+    extra_unique_dirs: list[str] = []
+    for d in extra_lm_paths:
+        norm = os.path.normcase(os.path.normpath(d))
+        if norm not in seen_dirs:
+            seen_dirs.add(norm)
+            all_unet_dirs.append(d)
+            extra_unique_dirs.append(d)
+
+    if extra_lm_paths:
+        if extra_unique_dirs:
+            logger.info(
+                "[Metadata Lib] Found %d extra UNet path(s) from LoraManager settings.",
+                len(extra_unique_dirs),
+            )
+        else:
+            logger.info(
+                "[Metadata Lib] LoraManager settings.json defined UNet paths,"
+                " but all are already covered by existing UNet directories.",
+            )
+
+    for unet_dir in all_unet_dirs:
+        for root, _, files in os.walk(unet_dir):
+            for file in files:
+                file_base, file_ext = os.path.splitext(file)
+                if file_ext in extensions and file_base not in _UNET_INDEX:
+                    _UNET_INDEX[file_base] = {
+                        "filename": file,
+                        "abspath": os.path.join(root, file),
+                    }
+
+    _UNET_INDEX_BUILT = True
+    logger.info("[Metadata Lib] UNet index built with %d entries.", len(_UNET_INDEX))
+    try:
+        if dump_env := os.environ.get("METADATA_DUMP_UNET_INDEX"):
+            dump_path = dump_env.strip()
+            if dump_path.lower() == "1":
+                dump_path = os.path.join(os.getcwd(), "_unet_index_dump.json")
+            with open(dump_path, "w", encoding="utf-8") as f:
+                json.dump(_UNET_INDEX, f, indent=2, sort_keys=True)
+            logger.info("[Metadata Lib] UNet index dumped to %s", dump_path)
+    except Exception as e:  # pragma: no cover - diagnostic optional
+        logger.debug("[Metadata Lib] Failed dumping UNet index: %r", e)
+
+
+def find_unet_info(base_name: str) -> dict[str, str] | None:
+    """Find the indexed information for a UNet by its base name.
+
+    Args:
+        base_name (str): The base name of the UNet file (without the
+            extension).
+
+    Returns:
+        dict[str, str] | None: A dictionary containing the ``filename`` and
+            ``abspath`` of the UNet, or None if not found.
+    """
+    build_unet_index()
+    if _UNET_INDEX is None:
+        return None
+    return _UNET_INDEX.get(base_name)
+
+
 # -----------------------------
 # Shared LoRA syntax utilities
 # -----------------------------
@@ -395,8 +613,13 @@ def resolve_lora_display_names(raw_names: list[str]) -> list[str]:
 
 
 __all__ = [
+    "get_lora_manager_paths",
     "build_lora_index",
     "find_lora_info",
+    "build_checkpoint_index",
+    "find_checkpoint_info",
+    "build_unet_index",
+    "find_unet_info",
     # syntax helpers
     "STRICT",
     "LEGACY",

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -147,7 +147,7 @@ def _read_lora_manager_settings(plugin_root: str) -> dict | None:
 
 
 def get_lora_manager_paths(model_type: str) -> list[str]:
-    """Return extra model directory paths from LoraManager's settings.json.
+    """Return model directory paths configured by LoraManager's settings.json.
 
     Reads from both ``extra_folder_paths.<model_type>`` and
     ``folder_paths.<model_type>`` keys in the settings file.
@@ -303,12 +303,14 @@ def build_lora_index() -> None:
     logger.info("[Metadata Lib] LoRA index built with %d entries.", len(_LORA_INDEX))
     try:
         if dump_env := os.environ.get("METADATA_DUMP_LORA_INDEX"):
+            # Whitespace-only env value is treated as unset.
             dump_path = dump_env.strip()
-            if dump_path.lower() == "1":
-                dump_path = os.path.join(os.getcwd(), "_lora_index_dump.json")
-            with open(dump_path, "w", encoding="utf-8") as f:
-                json.dump(_LORA_INDEX, f, indent=2, sort_keys=True)
-            logger.info("[Metadata Lib] LoRA index dumped to %s", dump_path)
+            if dump_path:
+                if dump_path.lower() == "1":
+                    dump_path = os.path.join(os.getcwd(), "_lora_index_dump.json")
+                with open(dump_path, "w", encoding="utf-8") as f:
+                    json.dump(_LORA_INDEX, f, indent=2, sort_keys=True)
+                logger.info("[Metadata Lib] LoRA index dumped to %s", dump_path)
     except Exception as e:  # pragma: no cover - diagnostic optional
         logger.debug("[Metadata Lib] Failed dumping LoRA index: %r", e)
 
@@ -433,12 +435,14 @@ def build_checkpoint_index() -> None:
     logger.info("[Metadata Lib] Checkpoint index built with %d entries.", len(_CHECKPOINT_INDEX))
     try:
         if dump_env := os.environ.get("METADATA_DUMP_CHECKPOINT_INDEX"):
+            # Whitespace-only env value is treated as unset.
             dump_path = dump_env.strip()
-            if dump_path.lower() == "1":
-                dump_path = os.path.join(os.getcwd(), "_checkpoint_index_dump.json")
-            with open(dump_path, "w", encoding="utf-8") as f:
-                json.dump(_CHECKPOINT_INDEX, f, indent=2, sort_keys=True)
-            logger.info("[Metadata Lib] Checkpoint index dumped to %s", dump_path)
+            if dump_path:
+                if dump_path.lower() == "1":
+                    dump_path = os.path.join(os.getcwd(), "_checkpoint_index_dump.json")
+                with open(dump_path, "w", encoding="utf-8") as f:
+                    json.dump(_CHECKPOINT_INDEX, f, indent=2, sort_keys=True)
+                logger.info("[Metadata Lib] Checkpoint index dumped to %s", dump_path)
     except Exception as e:  # pragma: no cover - diagnostic optional
         logger.debug("[Metadata Lib] Failed dumping checkpoint index: %r", e)
 
@@ -551,12 +555,14 @@ def build_unet_index() -> None:
     logger.info("[Metadata Lib] UNet index built with %d entries.", len(_UNET_INDEX))
     try:
         if dump_env := os.environ.get("METADATA_DUMP_UNET_INDEX"):
+            # Whitespace-only env value is treated as unset.
             dump_path = dump_env.strip()
-            if dump_path.lower() == "1":
-                dump_path = os.path.join(os.getcwd(), "_unet_index_dump.json")
-            with open(dump_path, "w", encoding="utf-8") as f:
-                json.dump(_UNET_INDEX, f, indent=2, sort_keys=True)
-            logger.info("[Metadata Lib] UNet index dumped to %s", dump_path)
+            if dump_path:
+                if dump_path.lower() == "1":
+                    dump_path = os.path.join(os.getcwd(), "_unet_index_dump.json")
+                with open(dump_path, "w", encoding="utf-8") as f:
+                    json.dump(_UNET_INDEX, f, indent=2, sort_keys=True)
+                logger.info("[Metadata Lib] UNet index dumped to %s", dump_path)
     except Exception as e:  # pragma: no cover - diagnostic optional
         logger.debug("[Metadata Lib] Failed dumping UNet index: %r", e)
 

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -282,8 +282,11 @@ def build_lora_index() -> None:
             for root, _, files in os.walk(lora_dir, onerror=_walk_error):
                 for file in files:
                     file_base, file_ext = os.path.splitext(file)
-                    # Use the base name as the key for easy lookup
-                    if file_ext in extensions and file_base not in _LORA_INDEX:
+                    # Use the base name as the key for easy lookup. Normalize the
+                    # extension to lower-case so files with upper-case suffixes
+                    # (e.g. `.SAFETENSORS`) are indexed, mirroring the behavior
+                    # of `build_checkpoint_index` and `build_unet_index`.
+                    if file_ext.lower() in extensions and file_base not in _LORA_INDEX:
                         _LORA_INDEX[file_base] = {
                             "filename": file,
                             "abspath": os.path.join(root, file),

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -392,7 +392,7 @@ def build_checkpoint_index() -> None:
         for root, _, files in os.walk(ckpt_dir):
             for file in files:
                 file_base, file_ext = os.path.splitext(file)
-                if file_ext in extensions and file_base not in _CHECKPOINT_INDEX:
+                if file_ext.lower() in extensions and file_base not in _CHECKPOINT_INDEX:
                     _CHECKPOINT_INDEX[file_base] = {
                         "filename": file,
                         "abspath": os.path.join(root, file),
@@ -497,7 +497,7 @@ def build_unet_index() -> None:
         for root, _, files in os.walk(unet_dir):
             for file in files:
                 file_base, file_ext = os.path.splitext(file)
-                if file_ext in extensions and file_base not in _UNET_INDEX:
+                if file_ext.lower() in extensions and file_base not in _UNET_INDEX:
                     _UNET_INDEX[file_base] = {
                         "filename": file,
                         "abspath": os.path.join(root, file),

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -337,8 +337,9 @@ def build_checkpoint_index() -> None:
         - unset or ``""``: skip writing a dump file;
         - ``"1"``: write JSON to
           ``os.path.join(os.getcwd(), "_checkpoint_index_dump.json")``;
-        - any other non-empty value: strip it and treat it as the output
-          file path.
+        - any other non-empty value: trim leading and trailing
+          whitespace with ``str.strip()`` and treat the result as the
+          output file path.
 
     Side Effects:
         Mutates module-level caches ``_CHECKPOINT_INDEX`` and
@@ -441,8 +442,9 @@ def build_unet_index() -> None:
         - unset or ``""``: skip writing a dump file;
         - ``"1"``: write JSON to
           ``os.path.join(os.getcwd(), "_unet_index_dump.json")``;
-        - any other non-empty value: strip it and treat it as the output
-          file path.
+        - any other non-empty value: trim leading and trailing
+          whitespace with ``str.strip()`` and treat the result as the
+          output file path.
 
     Side Effects:
         Mutates module-level caches ``_UNET_INDEX`` and

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -272,15 +272,29 @@ def build_lora_index() -> None:
             )
 
     for lora_dir in all_lora_dirs:
-        for root, _, files in os.walk(lora_dir):
-            for file in files:
-                file_base, file_ext = os.path.splitext(file)
-                # Use the base name as the key for easy lookup
-                if file_ext in extensions and file_base not in _LORA_INDEX:
-                    _LORA_INDEX[file_base] = {
-                        "filename": file,
-                        "abspath": os.path.join(root, file),
-                    }
+        def _walk_error(exc: OSError, _dir: str = lora_dir) -> None:
+            logger.warning(
+                "[Metadata Lib] Skipping unreadable LoRA path during index build: %s (%r)",
+                _dir,
+                exc,
+            )
+        try:
+            for root, _, files in os.walk(lora_dir, onerror=_walk_error):
+                for file in files:
+                    file_base, file_ext = os.path.splitext(file)
+                    # Use the base name as the key for easy lookup
+                    if file_ext in extensions and file_base not in _LORA_INDEX:
+                        _LORA_INDEX[file_base] = {
+                            "filename": file,
+                            "abspath": os.path.join(root, file),
+                        }
+        except OSError as exc:
+            logger.warning(
+                "[Metadata Lib] Aborted walk of LoRA directory %s during index build: %r",
+                lora_dir,
+                exc,
+            )
+            continue
 
     _LORA_INDEX_BUILT = True
     logger.info("[Metadata Lib] LoRA index built with %d entries.", len(_LORA_INDEX))
@@ -389,14 +403,28 @@ def build_checkpoint_index() -> None:
             )
 
     for ckpt_dir in all_ckpt_dirs:
-        for root, _, files in os.walk(ckpt_dir):
-            for file in files:
-                file_base, file_ext = os.path.splitext(file)
-                if file_ext.lower() in extensions and file_base not in _CHECKPOINT_INDEX:
-                    _CHECKPOINT_INDEX[file_base] = {
-                        "filename": file,
-                        "abspath": os.path.join(root, file),
-                    }
+        def _walk_error(exc: OSError, _dir: str = ckpt_dir) -> None:
+            logger.warning(
+                "[Metadata Lib] Skipping unreadable checkpoint path during index build: %s (%r)",
+                _dir,
+                exc,
+            )
+        try:
+            for root, _, files in os.walk(ckpt_dir, onerror=_walk_error):
+                for file in files:
+                    file_base, file_ext = os.path.splitext(file)
+                    if file_ext.lower() in extensions and file_base not in _CHECKPOINT_INDEX:
+                        _CHECKPOINT_INDEX[file_base] = {
+                            "filename": file,
+                            "abspath": os.path.join(root, file),
+                        }
+        except OSError as exc:
+            logger.warning(
+                "[Metadata Lib] Aborted walk of checkpoint directory %s during index build: %r",
+                ckpt_dir,
+                exc,
+            )
+            continue
 
     _CHECKPOINT_INDEX_BUILT = True
     logger.info("[Metadata Lib] Checkpoint index built with %d entries.", len(_CHECKPOINT_INDEX))
@@ -494,14 +522,28 @@ def build_unet_index() -> None:
             )
 
     for unet_dir in all_unet_dirs:
-        for root, _, files in os.walk(unet_dir):
-            for file in files:
-                file_base, file_ext = os.path.splitext(file)
-                if file_ext.lower() in extensions and file_base not in _UNET_INDEX:
-                    _UNET_INDEX[file_base] = {
-                        "filename": file,
-                        "abspath": os.path.join(root, file),
-                    }
+        def _walk_error(exc: OSError, _dir: str = unet_dir) -> None:
+            logger.warning(
+                "[Metadata Lib] Skipping unreadable UNet path during index build: %s (%r)",
+                _dir,
+                exc,
+            )
+        try:
+            for root, _, files in os.walk(unet_dir, onerror=_walk_error):
+                for file in files:
+                    file_base, file_ext = os.path.splitext(file)
+                    if file_ext.lower() in extensions and file_base not in _UNET_INDEX:
+                        _UNET_INDEX[file_base] = {
+                            "filename": file,
+                            "abspath": os.path.join(root, file),
+                        }
+        except OSError as exc:
+            logger.warning(
+                "[Metadata Lib] Aborted walk of UNet directory %s during index build: %r",
+                unet_dir,
+                exc,
+            )
+            continue
 
     _UNET_INDEX_BUILT = True
     logger.info("[Metadata Lib] UNet index built with %d entries.", len(_UNET_INDEX))

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -331,9 +331,20 @@ def build_checkpoint_index() -> None:
     paths from LoraManager's settings (forward-compat — not currently
     populated by LoraManager).
 
+    Environment:
+        ``METADATA_DUMP_CHECKPOINT_INDEX`` optionally writes the built
+        index to disk for diagnostics or tests. The current behavior is:
+        - unset or ``""``: skip writing a dump file;
+        - ``"1"``: write JSON to
+          ``os.path.join(os.getcwd(), "_checkpoint_index_dump.json")``;
+        - any other non-empty value: strip it and treat it as the output
+          file path.
+
     Side Effects:
         Mutates module-level caches ``_CHECKPOINT_INDEX`` and
-        ``_CHECKPOINT_INDEX_BUILT``.
+        ``_CHECKPOINT_INDEX_BUILT``. When
+        ``METADATA_DUMP_CHECKPOINT_INDEX`` is set as described above,
+        also writes a JSON dump of ``_CHECKPOINT_INDEX`` to disk.
     """
     global _CHECKPOINT_INDEX, _CHECKPOINT_INDEX_BUILT
     if _CHECKPOINT_INDEX_BUILT:
@@ -424,9 +435,20 @@ def build_unet_index() -> None:
     LoraManager's settings (forward-compat — not currently populated by
     LoraManager).
 
+    Environment:
+        ``METADATA_DUMP_UNET_INDEX`` optionally writes the built index to
+        disk for diagnostics or tests. The current behavior is:
+        - unset or ``""``: skip writing a dump file;
+        - ``"1"``: write JSON to
+          ``os.path.join(os.getcwd(), "_unet_index_dump.json")``;
+        - any other non-empty value: strip it and treat it as the output
+          file path.
+
     Side Effects:
         Mutates module-level caches ``_UNET_INDEX`` and
-        ``_UNET_INDEX_BUILT``.
+        ``_UNET_INDEX_BUILT``. When ``METADATA_DUMP_UNET_INDEX`` is set
+        as described above, also writes a JSON dump of ``_UNET_INDEX``
+        to disk.
     """
     global _UNET_INDEX, _UNET_INDEX_BUILT
     if _UNET_INDEX_BUILT:

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -334,10 +334,10 @@ def find_lora_info(base_name: str) -> dict[str, str] | None:
 
 
 # ---------------------------------------------------------------------------
-# TODO: LoraManager currently only populates extra_folder_paths.loras in
-#   practice, so build_checkpoint_index and build_unet_index will typically
-#   return no extra paths. These functions are implemented for forward
-#   compatibility when LoraManager expands its extra-paths support.
+# Note: LoraManager (and similar integrations) may register extra paths for
+# any model kind — loras, checkpoints, UNet, or embeddings — depending on
+# the user's settings. The index builders below treat the "no extra paths"
+# case as normal and never assume a particular integration populates them.
 # ---------------------------------------------------------------------------
 
 
@@ -346,8 +346,8 @@ def build_checkpoint_index() -> None:
 
     Mirrors :func:`build_lora_index` for checkpoint files.  Scans
     ``folder_paths.get_folder_paths('checkpoints')`` plus any extra
-    paths from LoraManager's settings (forward-compat — not currently
-    populated by LoraManager).
+    checkpoint paths configured via LoraManager's settings, when
+    present.
 
     Environment:
         ``METADATA_DUMP_CHECKPOINT_INDEX`` optionally writes the built
@@ -464,9 +464,8 @@ def build_unet_index() -> None:
     """Populate (idempotently) the in-memory UNet file index.
 
     Mirrors :func:`build_lora_index` for UNet files.  Scans
-    ``folder_paths.get_folder_paths('unet')`` plus any extra paths from
-    LoraManager's settings (forward-compat — not currently populated by
-    LoraManager).
+    ``folder_paths.get_folder_paths('unet')`` plus any extra UNet paths
+    configured via LoraManager's settings, when present.
 
     Environment:
         ``METADATA_DUMP_UNET_INDEX`` optionally writes the built index to

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -176,7 +176,8 @@ def get_lora_manager_paths(model_type: str) -> list[str]:
             continue
         for p in section.get(model_type, []):
             if isinstance(p, str) and p.strip():
-                paths.append(p.strip())
+                normalized = os.path.abspath(os.path.expanduser(p.strip()))
+                paths.append(normalized)
 
     # Deduplicate (case-insensitive on Windows) while preserving order.
     seen: set[str] = set()

--- a/saveimage_unimeta/utils/lora.py
+++ b/saveimage_unimeta/utils/lora.py
@@ -9,6 +9,7 @@ Includes:
 * One-time index mapping checkpoint/UNet base names to on-disk locations.
 """
 
+import json
 import logging
 import os
 import platform
@@ -16,7 +17,7 @@ import re
 
 import folder_paths
 from .pathresolve import SUPPORTED_MODEL_EXTENSIONS
-import json
+
 
 # --- Caches and Indexes for Performance ---
 # This index will be built once and reused to speed up all subsequent LoRA lookups.

--- a/tests/test_formatters_embeddings.py
+++ b/tests/test_formatters_embeddings.py
@@ -1,6 +1,8 @@
 import importlib
 import types
 
+import pytest
+
 
 def _make_clip(tmp_path, identifier="embedding:"):
     clip_core = types.SimpleNamespace(
@@ -46,6 +48,44 @@ def test_extract_embedding_names_skips_whitespace_candidates(monkeypatch, tmp_pa
 def test_extract_embedding_hashes_without_clip_returns_na(monkeypatch):
     fmt = importlib.import_module("ComfyUI_SaveImageWithMetaDataUniversal.saveimage_unimeta.defs.formatters")
     monkeypatch.setattr(fmt, "token_weights", lambda text: [(text, 1.0)])
+    hashes = fmt.extract_embedding_hashes("embedding:EasyNegative", ({"text": ["embedding:EasyNegative"]},))
+    assert hashes == ["N/A"]
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [("METADATA_TEST_MODE", "1"), ("PYTEST_CURRENT_TEST", "tests/test_formatters_embeddings.py::test")],
+)
+def test_get_lm_embedding_dirs_skips_lora_manager_reads_in_test_mode(monkeypatch, env_name, env_value):
+    fmt = importlib.import_module("ComfyUI_SaveImageWithMetaDataUniversal.saveimage_unimeta.defs.formatters")
+    monkeypatch.setattr(fmt, "_LM_EMBEDDING_DIRS_CACHE", None)
+    monkeypatch.setenv(env_name, env_value)
+    if env_name != "METADATA_TEST_MODE":
+        monkeypatch.delenv("METADATA_TEST_MODE", raising=False)
+    if env_name != "PYTEST_CURRENT_TEST":
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    def _unexpected_call(_model_type):
+        raise AssertionError("get_lora_manager_paths should not run in test mode")
+
+    monkeypatch.setattr(fmt, "get_lora_manager_paths", _unexpected_call)
+
+    assert fmt._get_lm_embedding_dirs() == []
+    assert fmt._LM_EMBEDDING_DIRS_CACHE is None
+
+
+def test_extract_embedding_hashes_without_clip_skips_lora_manager_reads_in_test_mode(monkeypatch):
+    fmt = importlib.import_module("ComfyUI_SaveImageWithMetaDataUniversal.saveimage_unimeta.defs.formatters")
+    monkeypatch.setattr(fmt, "token_weights", lambda text: [(text, 1.0)])
+    monkeypatch.setattr(fmt, "_LM_EMBEDDING_DIRS_CACHE", None)
+    monkeypatch.setenv("METADATA_TEST_MODE", "1")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    def _unexpected_call(_model_type):
+        raise AssertionError("get_lora_manager_paths should not run in test mode")
+
+    monkeypatch.setattr(fmt, "get_lora_manager_paths", _unexpected_call)
+
     hashes = fmt.extract_embedding_hashes("embedding:EasyNegative", ({"text": ["embedding:EasyNegative"]},))
     assert hashes == ["N/A"]
 

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -1,4 +1,5 @@
 import logging
+import types
 
 from saveimage_unimeta.defs import formatters
 
@@ -48,3 +49,47 @@ def test_hash_skipped_reason_debug(monkeypatch):
     assert "hash skipped reason=unresolved token=does_not_exist_model_123" in log_all
     assert "hash skipped reason=unresolved token=ghost_lora_999" in log_all
     assert "hash skipped reason=unresolved token=phantom_unet_777" in log_all
+
+
+def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypatch):
+    model_file = tmp_path / "checkpoints" / "retryModel.safetensors"
+    model_file.parent.mkdir(parents=True, exist_ok=True)
+    model_file.write_text("content-retry", encoding="utf-8")
+
+    def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
+        resolved = post_resolvers[0]("nested/retryModel.safetensors") if post_resolvers else None
+        return types.SimpleNamespace(display_name="retryModel", full_path=resolved)
+
+    monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
+    monkeypatch.setattr(
+        formatters,
+        "find_checkpoint_info",
+        lambda key: {"abspath": str(model_file)} if key == "retryModel" else None,
+    )
+
+    display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
+
+    assert display == "retryModel"
+    assert path == str(model_file)
+
+
+def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypatch):
+    model_file = tmp_path / "unet" / "flux1-dev.safetensors"
+    model_file.parent.mkdir(parents=True, exist_ok=True)
+    model_file.write_text("content-unet", encoding="utf-8")
+
+    def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
+        resolved = post_resolvers[0]("nested/flux1-dev.safetensors") if post_resolvers else None
+        return types.SimpleNamespace(display_name="flux1-dev", full_path=resolved)
+
+    monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
+    monkeypatch.setattr(
+        formatters,
+        "find_unet_info",
+        lambda key: {"abspath": str(model_file)} if key == "flux1-dev" else None,
+    )
+    monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
+
+    result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)
+
+    assert result == "1234567890"

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -61,12 +61,14 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
         resolved = post_resolvers[0]("nested/retryModel.safetensors") if post_resolvers else None
         return types.SimpleNamespace(display_name="retryModel", full_path=resolved)
 
+    def _fake_find_checkpoint_info(key):
+        queried_keys.append(key)
+        if key == "retryModel":
+            return {"abspath": str(model_file)}
+        return None
+
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
-    monkeypatch.setattr(
-        formatters,
-        "find_checkpoint_info",
-        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "retryModel" else None),
-    )
+    monkeypatch.setattr(formatters, "find_checkpoint_info", _fake_find_checkpoint_info)
 
     display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
 
@@ -85,12 +87,14 @@ def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
         resolved = post_resolvers[0]("nested/flux1-dev.safetensors") if post_resolvers else None
         return types.SimpleNamespace(display_name="flux1-dev", full_path=resolved)
 
+    def _fake_find_unet_info(key):
+        queried_keys.append(key)
+        if key == "flux1-dev":
+            return {"abspath": str(model_file)}
+        return None
+
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
-    monkeypatch.setattr(
-        formatters,
-        "find_unet_info",
-        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "flux1-dev" else None),
-    )
+    monkeypatch.setattr(formatters, "find_unet_info", _fake_find_unet_info)
     monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
 
     result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -69,6 +69,8 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
 
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
     monkeypatch.setattr(formatters, "find_checkpoint_info", _fake_find_checkpoint_info)
+    # Force the index resolver to engage even though LoraManager isn't installed in CI.
+    monkeypatch.setattr(formatters, "_get_lm_checkpoint_dirs", lambda: ["<test-lm-dir>"])
 
     display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
 
@@ -96,6 +98,8 @@ def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
     monkeypatch.setattr(formatters, "find_unet_info", _fake_find_unet_info)
     monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
+    # Force the index resolver to engage even though LoraManager isn't installed in CI.
+    monkeypatch.setattr(formatters, "_get_lm_unet_dirs", lambda: ["<test-lm-dir>"])
 
     result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)
 

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -55,6 +55,7 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     model_file = tmp_path / "checkpoints" / "retryModel.safetensors"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("content-retry", encoding="utf-8")
+    queried_keys: list[str] = []
 
     def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
         resolved = post_resolvers[0]("nested/retryModel.safetensors") if post_resolvers else None
@@ -64,19 +65,21 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     monkeypatch.setattr(
         formatters,
         "find_checkpoint_info",
-        lambda key: {"abspath": str(model_file)} if key == "retryModel" else None,
+        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "retryModel" else None),
     )
 
     display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
 
     assert display == "retryModel"
     assert path == str(model_file)
+    assert queried_keys == ["retryModel"]
 
 
 def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypatch):
     model_file = tmp_path / "unet" / "flux1-dev.safetensors"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("content-unet", encoding="utf-8")
+    queried_keys: list[str] = []
 
     def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
         resolved = post_resolvers[0]("nested/flux1-dev.safetensors") if post_resolvers else None
@@ -86,10 +89,11 @@ def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     monkeypatch.setattr(
         formatters,
         "find_unet_info",
-        lambda key: {"abspath": str(model_file)} if key == "flux1-dev" else None,
+        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "flux1-dev" else None),
     )
     monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
 
     result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)
 
     assert result == "1234567890"
+    assert queried_keys == ["flux1-dev"]

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -515,6 +515,23 @@ def test_build_checkpoint_index_no_lora_manager_installed(monkeypatch, tmp_path)
     assert find_checkpoint_info("standard-model") is not None
 
 
+def test_build_checkpoint_index_accepts_uppercase_extensions(monkeypatch, tmp_path):
+    """Checkpoint indexing accepts uppercase supported file extensions."""
+    ckpt_dir = tmp_path / "ckpts"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "upper-model.SAFETENSORS").write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(ckpt_dir)] if kind == "checkpoints" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [])
+    _reset_checkpoint_index()
+
+    build_checkpoint_index()
+
+    info = find_checkpoint_info("upper-model")
+    assert info is not None
+    assert info["filename"] == "upper-model.SAFETENSORS"
+
+
 def test_find_checkpoint_info_stem_only_lookup(monkeypatch, tmp_path):
     """find_checkpoint_info index key is stem only; resolver must strip extension before lookup."""
     ckpt_dir = tmp_path / "ckpts"
@@ -591,3 +608,20 @@ def test_build_unet_index_no_lora_manager_installed(monkeypatch, tmp_path):
 
     build_unet_index()
     assert find_unet_info("standard-unet") is not None
+
+
+def test_build_unet_index_accepts_uppercase_extensions(monkeypatch, tmp_path):
+    """UNet indexing accepts uppercase supported file extensions."""
+    unet_dir = tmp_path / "unets"
+    unet_dir.mkdir()
+    (unet_dir / "upper-unet.SAFETENSORS").write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(unet_dir)] if kind == "unet" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [])
+    _reset_unet_index()
+
+    build_unet_index()
+
+    info = find_unet_info("upper-unet")
+    assert info is not None
+    assert info["filename"] == "upper-unet.SAFETENSORS"

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -13,6 +13,11 @@ from saveimage_unimeta.utils.lora import (
     _read_lora_manager_settings,
     build_lora_index,
     find_lora_info,
+    get_lora_manager_paths,
+    build_checkpoint_index,
+    find_checkpoint_info,
+    build_unet_index,
+    find_unet_info,
 )
 
 
@@ -25,15 +30,31 @@ def _reset_index():
     lora_mod._LORA_INDEX_BUILT = False
 
 
-def _make_settings(extra_dir: str = "", folder_dir: str = "", portable: bool = False) -> dict:
+def _reset_checkpoint_index():
+    lora_mod._CHECKPOINT_INDEX = None
+    lora_mod._CHECKPOINT_INDEX_BUILT = False
+
+
+def _reset_unet_index():
+    lora_mod._UNET_INDEX = None
+    lora_mod._UNET_INDEX_BUILT = False
+
+
+def _reset_all_indexes():
+    _reset_index()
+    _reset_checkpoint_index()
+    _reset_unet_index()
+
+
+def _make_settings(extra_dir: str = "", folder_dir: str = "", portable: bool = False, model_type: str = "loras") -> dict:
     """Build a minimal LoraManager settings dict for testing."""
     data: dict = {}
     if portable:
         data["use_portable_settings"] = True
     if extra_dir:
-        data["extra_folder_paths"] = {"loras": [extra_dir]}
+        data["extra_folder_paths"] = {model_type: [extra_dir]}
     if folder_dir:
-        data["folder_paths"] = {"loras": [folder_dir]}
+        data["folder_paths"] = {model_type: [folder_dir]}
     return data
 
 
@@ -301,6 +322,20 @@ def test_lora_paths_tolerates_missing_loras_key(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _get_lora_manager_lora_paths / get_lora_manager_paths
+# ---------------------------------------------------------------------------
+
+def test_get_lora_manager_paths_reads_non_lora_type(tmp_path, monkeypatch):
+    """get_lora_manager_paths returns paths for non-lora model types."""
+    settings = {"extra_folder_paths": {"checkpoints": ["/ckpt/extra"]}}
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+
+    result = get_lora_manager_paths("checkpoints")
+    assert result == ["/ckpt/extra"]
+
+
+# ---------------------------------------------------------------------------
 # build_lora_index integration
 # ---------------------------------------------------------------------------
 
@@ -390,3 +425,142 @@ def test_build_lora_index_deduplicates_overlapping_paths(monkeypatch, tmp_path):
     assert info["filename"] == "overlap-lora.safetensors"
     # The directory must have been walked only once
     assert walk_calls.count(str(shared_dir)) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_checkpoint_index integration
+# ---------------------------------------------------------------------------
+
+def test_build_checkpoint_index_includes_extra_lora_manager_paths(monkeypatch, tmp_path):
+    """Checkpoints stored only in LoraManager extra paths are indexed and findable."""
+    standard_dir = tmp_path / "standard_ckpts"
+    standard_dir.mkdir()
+
+    extra_dir = tmp_path / "extra_ckpts"
+    extra_dir.mkdir()
+    ckpt_file = extra_dir / "my-model.safetensors"
+    ckpt_file.write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "checkpoints" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [str(extra_dir)] if model_type == "checkpoints" else [])
+    _reset_checkpoint_index()
+
+    build_checkpoint_index()
+    info = find_checkpoint_info("my-model")
+    assert info is not None, "Expected my-model to be found in the extra path"
+    assert info["filename"] == "my-model.safetensors"
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(ckpt_file))
+
+
+def test_build_checkpoint_index_standard_path_takes_priority_over_extra(monkeypatch, tmp_path):
+    """When the same stem exists in both standard and extra paths, the standard path wins."""
+    standard_dir = tmp_path / "standard"
+    standard_dir.mkdir()
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+
+    std_file = standard_dir / "base-model.safetensors"
+    std_file.write_bytes(b"standard")
+    extra_file = extra_dir / "base-model.safetensors"
+    extra_file.write_bytes(b"extra")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "checkpoints" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [str(extra_dir)] if model_type == "checkpoints" else [])
+    _reset_checkpoint_index()
+
+    build_checkpoint_index()
+    info = find_checkpoint_info("base-model")
+    assert info is not None
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(std_file))
+
+
+def test_build_checkpoint_index_no_lora_manager_installed(monkeypatch, tmp_path):
+    """build_checkpoint_index works normally when LoraManager returns no extra paths."""
+    ckpt_dir = tmp_path / "ckpts"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "standard-model.safetensors").write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(ckpt_dir)] if kind == "checkpoints" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [])
+    _reset_checkpoint_index()
+
+    build_checkpoint_index()
+    assert find_checkpoint_info("standard-model") is not None
+
+
+def test_find_checkpoint_info_stem_only_lookup(monkeypatch, tmp_path):
+    """find_checkpoint_info index key is stem only; resolver must strip extension before lookup."""
+    ckpt_dir = tmp_path / "ckpts"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "big-model.safetensors").write_bytes(b"data")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(ckpt_dir)] if kind == "checkpoints" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [])
+    _reset_checkpoint_index()
+
+    build_checkpoint_index()
+    # Lookup by stem succeeds
+    assert find_checkpoint_info("big-model") is not None
+    # Lookup by full filename fails (as expected — callers must strip ext)
+    assert find_checkpoint_info("big-model.safetensors") is None
+
+
+# ---------------------------------------------------------------------------
+# build_unet_index integration
+# ---------------------------------------------------------------------------
+
+def test_build_unet_index_includes_extra_lora_manager_paths(monkeypatch, tmp_path):
+    """UNets stored only in LoraManager extra paths are indexed and findable."""
+    standard_dir = tmp_path / "standard_unets"
+    standard_dir.mkdir()
+
+    extra_dir = tmp_path / "extra_unets"
+    extra_dir.mkdir()
+    unet_file = extra_dir / "flux-unet.safetensors"
+    unet_file.write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "unet" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [str(extra_dir)] if model_type == "unet" else [])
+    _reset_unet_index()
+
+    build_unet_index()
+    info = find_unet_info("flux-unet")
+    assert info is not None, "Expected flux-unet to be found in the extra path"
+    assert info["filename"] == "flux-unet.safetensors"
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(unet_file))
+
+
+def test_build_unet_index_standard_path_takes_priority_over_extra(monkeypatch, tmp_path):
+    """When the same stem exists in both standard and extra paths, the standard path wins."""
+    standard_dir = tmp_path / "standard"
+    standard_dir.mkdir()
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+
+    std_file = standard_dir / "flux1-dev.safetensors"
+    std_file.write_bytes(b"standard")
+    extra_file = extra_dir / "flux1-dev.safetensors"
+    extra_file.write_bytes(b"extra")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(standard_dir)] if kind == "unet" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [str(extra_dir)] if model_type == "unet" else [])
+    _reset_unet_index()
+
+    build_unet_index()
+    info = find_unet_info("flux1-dev")
+    assert info is not None
+    assert os.path.normcase(info["abspath"]) == os.path.normcase(str(std_file))
+
+
+def test_build_unet_index_no_lora_manager_installed(monkeypatch, tmp_path):
+    """build_unet_index works normally when LoraManager returns no extra paths."""
+    unet_dir = tmp_path / "unets"
+    unet_dir.mkdir()
+    (unet_dir / "standard-unet.safetensors").write_bytes(b"dummy")
+
+    monkeypatch.setattr(folder_paths, "get_folder_paths", lambda kind: [str(unet_dir)] if kind == "unet" else [])
+    monkeypatch.setattr(lora_mod, "get_lora_manager_paths", lambda model_type: [])
+    _reset_unet_index()
+
+    build_unet_index()
+    assert find_unet_info("standard-unet") is not None

--- a/tests/test_lora_manager_compat.py
+++ b/tests/test_lora_manager_compat.py
@@ -249,7 +249,7 @@ def test_lora_paths_from_extra_folder_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
 
     result = _get_lora_manager_lora_paths()
-    assert result == ["/extra/loras"]
+    assert result == [os.path.abspath("/extra/loras")]
 
 
 def test_lora_paths_from_folder_paths(tmp_path, monkeypatch):
@@ -259,7 +259,7 @@ def test_lora_paths_from_folder_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
 
     result = _get_lora_manager_lora_paths()
-    assert result == ["/library/loras"]
+    assert result == [os.path.abspath("/library/loras")]
 
 
 def test_lora_paths_merges_both_keys(tmp_path, monkeypatch):
@@ -272,8 +272,8 @@ def test_lora_paths_merges_both_keys(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
 
     result = _get_lora_manager_lora_paths()
-    assert "/extra/loras" in result
-    assert "/standard/loras" in result
+    assert os.path.abspath("/extra/loras") in result
+    assert os.path.abspath("/standard/loras") in result
     assert len(result) == 2
 
 
@@ -288,7 +288,7 @@ def test_lora_paths_deduplicates_same_path(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
 
     result = _get_lora_manager_lora_paths()
-    assert result == [shared]
+    assert result == [os.path.abspath(shared)]
 
 
 def test_lora_paths_returns_empty_when_plugin_not_installed(monkeypatch):
@@ -310,7 +310,7 @@ def test_lora_paths_ignores_empty_string_entries(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
     result = _get_lora_manager_lora_paths()
-    assert result == ["/real/path"]
+    assert result == [os.path.abspath("/real/path")]
 
 
 def test_lora_paths_tolerates_missing_loras_key(tmp_path, monkeypatch):
@@ -332,7 +332,34 @@ def test_get_lora_manager_paths_reads_non_lora_type(tmp_path, monkeypatch):
     monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
 
     result = get_lora_manager_paths("checkpoints")
-    assert result == ["/ckpt/extra"]
+    assert result == [os.path.abspath("/ckpt/extra")]
+
+
+def test_get_lora_manager_paths_normalizes_and_deduplicates_paths(tmp_path, monkeypatch):
+    """get_lora_manager_paths expands user-relative paths and deduplicates normalized entries."""
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    settings = {
+        "extra_folder_paths": {"checkpoints": ["models", "./models"]},
+        "folder_paths": {"checkpoints": ["~/ckpts"]},
+    }
+    real_expanduser = lora_mod.os.path.expanduser
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(lora_mod, "_find_lora_manager_root", lambda: str(tmp_path))
+    monkeypatch.setattr(lora_mod, "_read_lora_manager_settings", lambda _root: settings)
+    monkeypatch.setattr(
+        lora_mod.os.path,
+        "expanduser",
+        lambda value: str(home_dir / value[2:]) if value.startswith("~/") else real_expanduser(value),
+    )
+
+    result = get_lora_manager_paths("checkpoints")
+
+    assert result == [
+        os.path.abspath(str(tmp_path / "models")),
+        os.path.abspath(str(home_dir / "ckpts")),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils_embedding.py
+++ b/tests/test_utils_embedding.py
@@ -82,3 +82,55 @@ def test_get_embedding_file_path_errors_when_no_valid_dirs(monkeypatch):
 
     with pytest.raises(ValueError):
         embedding_mod.get_embedding_file_path("lion", clip)
+
+
+def test_get_embedding_file_path_clip_none_no_extra_dirs_returns_none():
+    """Returns None immediately when clip is None and no extra_dirs provided."""
+    result = embedding_mod.get_embedding_file_path("any-embedding", None)
+    assert result is None
+
+
+def test_get_embedding_file_path_clip_none_with_extra_dirs_found(tmp_path):
+    """Finds embedding via extra_dirs when clip is None."""
+    embed_dir = tmp_path / "lm_embeds"
+    embed_dir.mkdir()
+    target = embed_dir / "style-v1.safetensors"
+    target.write_bytes(b"data")
+
+    result = embedding_mod.get_embedding_file_path("style-v1", None, extra_dirs=[str(embed_dir)])
+    assert result == str(target)
+
+
+def test_get_embedding_file_path_extra_dirs_only_match(tmp_path):
+    """When embedding is only in extra_dirs (not clip dirs), it is found."""
+    clip_dir = tmp_path / "clip_embeds"
+    clip_dir.mkdir()
+    extra_dir = tmp_path / "extra_embeds"
+    extra_dir.mkdir()
+    target = extra_dir / "rare-embed.pt"
+    target.write_bytes(b"data")
+
+    clip = DummyClip(str(clip_dir))
+    result = embedding_mod.get_embedding_file_path("rare-embed", clip, extra_dirs=[str(extra_dir)])
+    assert result == str(target)
+
+
+def test_get_embedding_file_path_extra_dirs_traversal_guard_uses_continue(tmp_path):
+    """Traversal guard skips offending extra_dir entry (continue) and searches remaining dirs."""
+    safe_dir = tmp_path / "safe"
+    safe_dir.mkdir()
+    # 'sneaky_dir' is a sibling that could be escaped into
+    sneaky_dir = tmp_path / "sneaky"
+    sneaky_dir.mkdir()
+    target = safe_dir / "valid-embed.safetensors"
+    target.write_bytes(b"data")
+
+    # Using traversal name that escapes sneaky_dir — should be skipped, not abort entirely
+    # Then the safe_dir via a second call should still succeed
+    result_traversal = embedding_mod.get_embedding_file_path("../sneaky/escape", None, extra_dirs=[str(safe_dir)])
+    # The traversal resolves to outside safe_dir, so no match is found (returns None)
+    assert result_traversal is None
+
+    # A valid lookup in the same dir still works (proves continue not return None)
+    result_valid = embedding_mod.get_embedding_file_path("valid-embed", None, extra_dirs=[str(safe_dir)])
+    assert result_valid == str(target)

--- a/tests/test_utils_embedding.py
+++ b/tests/test_utils_embedding.py
@@ -115,22 +115,30 @@ def test_get_embedding_file_path_extra_dirs_only_match(tmp_path):
     assert result == str(target)
 
 
-def test_get_embedding_file_path_extra_dirs_traversal_guard_uses_continue(tmp_path):
-    """Traversal guard skips offending extra_dir entry (continue) and searches remaining dirs."""
+def test_get_embedding_file_path_extra_dirs_traversal_guard_returns_none(tmp_path):
+    """Traversal-style embedding name escaping the only extra_dir returns None (does not raise)."""
     safe_dir = tmp_path / "safe"
     safe_dir.mkdir()
-    # 'sneaky_dir' is a sibling that could be escaped into
     sneaky_dir = tmp_path / "sneaky"
     sneaky_dir.mkdir()
-    target = safe_dir / "valid-embed.safetensors"
+    # A real file exists outside safe_dir; the traversal guard must prevent reaching it.
+    (sneaky_dir / "escape.safetensors").write_bytes(b"data")
+
+    result = embedding_mod.get_embedding_file_path(
+        "../sneaky/escape", None, extra_dirs=[str(safe_dir)]
+    )
+    assert result is None
+
+
+def test_get_embedding_file_path_extra_dirs_continues_past_bad_entry(tmp_path):
+    """Loop skips a bad extra_dir entry and resolves from a later valid dir in the same call."""
+    missing_dir = tmp_path / "does_not_exist"  # not created -> isdir False -> continue
+    good_dir = tmp_path / "good"
+    good_dir.mkdir()
+    target = good_dir / "valid-embed.safetensors"
     target.write_bytes(b"data")
 
-    # Using traversal name that escapes sneaky_dir — should be skipped, not abort entirely
-    # Then the safe_dir via a second call should still succeed
-    result_traversal = embedding_mod.get_embedding_file_path("../sneaky/escape", None, extra_dirs=[str(safe_dir)])
-    # The traversal resolves to outside safe_dir, so no match is found (returns None)
-    assert result_traversal is None
-
-    # A valid lookup in the same dir still works (proves continue not return None)
-    result_valid = embedding_mod.get_embedding_file_path("valid-embed", None, extra_dirs=[str(safe_dir)])
-    assert result_valid == str(target)
+    result = embedding_mod.get_embedding_file_path(
+        "valid-embed", None, extra_dirs=[str(missing_dir), str(good_dir)]
+    )
+    assert result == str(target)


### PR DESCRIPTION
This pull request adds support for searching model files (embeddings, checkpoints, and UNet models) in extra directories defined by LoraManager, improving compatibility and flexibility when resolving file paths. It introduces new index-building and lookup utilities for checkpoints and UNet models, and extends embedding resolution to use LoraManager's settings. The changes also refactor and generalize the way extra model directories are discovered and used.

**LoraManager integration and path resolution enhancements:**

* Added `get_lora_manager_paths` to generalize fetching extra model directories (for loras, checkpoints, unet, embeddings) from LoraManager's settings, and updated all relevant logic to use this function. [[1]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aL143-R162) [[2]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aL166-R177) [[3]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aR192-R204) [[4]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aR616-R622) [[5]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047L54-R54)
* Embedding resolution (`get_embedding_file_path`) now accepts an `extra_dirs` argument, allowing it to search LoraManager-provided embedding directories in addition to or instead of the standard locations. [[1]](diffhunk://#diff-8b10a507cd1a5d855c0f71ce6f7d8c9351809b961ee9402601dd565b15227560L24-R33) [[2]](diffhunk://#diff-8b10a507cd1a5d855c0f71ce6f7d8c9351809b961ee9402601dd565b15227560L44-R52) [[3]](diffhunk://#diff-8b10a507cd1a5d855c0f71ce6f7d8c9351809b961ee9402601dd565b15227560R62-R101) [[4]](diffhunk://#diff-8b10a507cd1a5d855c0f71ce6f7d8c9351809b961ee9402601dd565b15227560L92-R117)
* Added a session-lifetime cache for LoraManager embedding directories to avoid repeated file I/O. [[1]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047R76-R78) [[2]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047R90-R97)
* The embedding extraction logic now passes LoraManager embedding directories to the resolver, ensuring embeddings found only via LoraManager can be located. [[1]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047R916) [[2]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047L937-R978)

**Checkpoint and UNet model indexing:**

* Implemented new index builders and lookup functions (`build_checkpoint_index`, `find_checkpoint_info`, `build_unet_index`, `find_unet_info`) for checkpoints and UNet models, mirroring the LoRA index logic and supporting extra directories from LoraManager. [[1]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aR25-R28) [[2]](diffhunk://#diff-600c5b1ba7090dba856e1e42ee1ad6394d460995ecb678878719fb8bf07f164aR317-R510)
* Updated checkpoint and UNet path resolution to use these new index-based resolvers, ensuring files in LoraManager's extra directories are found. [[1]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047L284-R300) [[2]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047R724-R730)

These changes improve the robustness and flexibility of model file resolution, especially in environments where LoraManager is used to manage additional model directories.