### PR TITLE
fix: simplify basename-only index resolvers

### DIFF
--- a/saveimage_unimeta/defs/formatters.py
+++ b/saveimage_unimeta/defs/formatters.py
@@ -296,9 +296,6 @@ def _ckpt_name_to_path(name_like: Any) -> tuple[str, str | None]:
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_checkpoint_info(key if key else basename)
-        if not info and basename != stem:
-            raw_key, _ = os.path.splitext(stem)
-            info = find_checkpoint_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     res = try_resolve_artifact("checkpoints", name_like, post_resolvers=[_ckpt_index_resolver])
@@ -729,9 +726,6 @@ def calc_unet_hash(model_name: Any, input_data: list) -> str:
         basename = os.path.basename(stem)
         key, _ = os.path.splitext(basename)
         info = find_unet_info(key if key else basename)
-        if not info and basename != stem:
-            raw_key, _ = os.path.splitext(stem)
-            info = find_unet_info(raw_key if raw_key else stem)
         return info["abspath"] if info else None
 
     # Unified attempt

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -61,12 +61,14 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
         resolved = post_resolvers[0]("nested/retryModel.safetensors") if post_resolvers else None
         return types.SimpleNamespace(display_name="retryModel", full_path=resolved)
 
+    def _fake_find_checkpoint_info(key):
+        queried_keys.append(key)
+        if key == "retryModel":
+            return {"abspath": str(model_file)}
+        return None
+
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
-    monkeypatch.setattr(
-        formatters,
-        "find_checkpoint_info",
-        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "retryModel" else None),
-    )
+    monkeypatch.setattr(formatters, "find_checkpoint_info", _fake_find_checkpoint_info)
 
     display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
 
@@ -85,12 +87,14 @@ def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
         resolved = post_resolvers[0]("nested/flux1-dev.safetensors") if post_resolvers else None
         return types.SimpleNamespace(display_name="flux1-dev", full_path=resolved)
 
+    def _fake_find_unet_info(key):
+        queried_keys.append(key)
+        if key == "flux1-dev":
+            return {"abspath": str(model_file)}
+        return None
+
     monkeypatch.setattr(formatters, "try_resolve_artifact", _fake_try_resolve_artifact)
-    monkeypatch.setattr(
-        formatters,
-        "find_unet_info",
-        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "flux1-dev" else None),
-    )
+    monkeypatch.setattr(formatters, "find_unet_info", _fake_find_unet_info)
     monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
 
     result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)

--- a/tests/test_hash_basename_and_skip_reasons.py
+++ b/tests/test_hash_basename_and_skip_reasons.py
@@ -55,6 +55,7 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     model_file = tmp_path / "checkpoints" / "retryModel.safetensors"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("content-retry", encoding="utf-8")
+    queried_keys: list[str] = []
 
     def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
         resolved = post_resolvers[0]("nested/retryModel.safetensors") if post_resolvers else None
@@ -64,19 +65,21 @@ def test_ckpt_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     monkeypatch.setattr(
         formatters,
         "find_checkpoint_info",
-        lambda key: {"abspath": str(model_file)} if key == "retryModel" else None,
+        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "retryModel" else None),
     )
 
     display, path = formatters._ckpt_name_to_path("nested/retryModel.safetensors")
 
     assert display == "retryModel"
     assert path == str(model_file)
+    assert queried_keys == ["retryModel"]
 
 
 def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypatch):
     model_file = tmp_path / "unet" / "flux1-dev.safetensors"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("content-unet", encoding="utf-8")
+    queried_keys: list[str] = []
 
     def _fake_try_resolve_artifact(_kind, _name_like, post_resolvers=None):
         resolved = post_resolvers[0]("nested/flux1-dev.safetensors") if post_resolvers else None
@@ -86,10 +89,11 @@ def test_unet_index_resolver_uses_basename_for_subdir_tokens(tmp_path, monkeypat
     monkeypatch.setattr(
         formatters,
         "find_unet_info",
-        lambda key: {"abspath": str(model_file)} if key == "flux1-dev" else None,
+        lambda key: queried_keys.append(key) or ({"abspath": str(model_file)} if key == "flux1-dev" else None),
     )
     monkeypatch.setattr(formatters, "_hash_file", lambda *_args, **_kwargs: "1234567890")
 
     result = formatters.calc_unet_hash("nested/flux1-dev.safetensors", None)
 
     assert result == "1234567890"
+    assert queried_keys == ["flux1-dev"]


### PR DESCRIPTION
This pull request simplifies the logic for resolving checkpoint and unet file paths by removing redundant code paths, and strengthens the associated tests to ensure only the intended lookup keys are used. The main focus is on code cleanup and improved test coverage.

### Code simplification

* Removed the fallback logic in `_ckpt_index_resolver` and `_unet_index_resolver` in `saveimage_unimeta/defs/formatters.py` that attempted to resolve using the original stem if the basename lookup failed. Now, only the basename is used for lookups, making the code more predictable and concise. [[1]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047L299-L301) [[2]](diffhunk://#diff-97f209f8a1bf27d939be3061b4dccd529d170f98168d5f4376c67863a4bd8047L732-L734)

### Test improvements

* Enhanced tests in `tests/test_hash_basename_and_skip_reasons.py` to track which keys are queried during checkpoint and unet info resolution, and added assertions to verify that only the expected basename is used. This ensures the resolvers do not attempt unnecessary or incorrect lookups. [[1]](diffhunk://#diff-5fc1f02fabb4e6286d7555d6527b1c7906f569360ef80ca5fc994a85e6455a3bR58) [[2]](diffhunk://#diff-5fc1f02fabb4e6286d7555d6527b1c7906f569360ef80ca5fc994a85e6455a3bL67-R82) [[3]](diffhunk://#diff-5fc1f02fabb4e6286d7555d6527b1c7906f569360ef80ca5fc994a85e6455a3bL89-R99)