### PR TITLE
Fix issue 63

### DIFF
--- a/.github/workflows/unimeta-ci.yml
+++ b/.github/workflows/unimeta-ci.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/saveimage_unimeta/nodes/extra_metadata.py
+++ b/saveimage_unimeta/nodes/extra_metadata.py
@@ -15,6 +15,46 @@ class CreateExtraMetaDataUniversal:
     modifying any configuration files.
     """
 
+    EXTRA_METADATA_PAIR_COUNT = 4
+
+    @classmethod
+    def _build_pair_inputs(cls, start_index, end_index):
+        """Build the repeated key/value string inputs for the node schema."""
+        pair_inputs = {}
+        for index in range(start_index, end_index + 1):
+            pair_inputs[f"key{index}"] = ("STRING", {"default": "", "multiline": False})
+            pair_inputs[f"value{index}"] = ("STRING", {"default": "", "multiline": False})
+        return pair_inputs
+
+    @classmethod
+    def _pair_field_names(cls):
+        """Return the ordered field names matching the declared key/value inputs."""
+        field_names = []
+        for index in range(1, cls.EXTRA_METADATA_PAIR_COUNT + 1):
+            field_names.extend((f"key{index}", f"value{index}"))
+        return tuple(field_names)
+
+    @classmethod
+    def _normalize_pair_arguments(cls, pair_args, pair_kwargs):
+        """Normalize positional and keyword pair inputs into a validated mapping."""
+        field_names = cls._pair_field_names()
+        if len(pair_args) > len(field_names):
+            raise TypeError(f"Expected at most {len(field_names)} pair values, got {len(pair_args)}")
+
+        unexpected_names = set(pair_kwargs) - set(field_names)
+        if unexpected_names:
+            unexpected_list = ", ".join(sorted(unexpected_names))
+            raise TypeError(f"Unexpected metadata arguments: {unexpected_list}")
+
+        normalized_pairs = {}
+        for field_name, field_value in zip(field_names, pair_args):
+            if field_name in pair_kwargs:
+                raise TypeError(f"Got multiple values for argument '{field_name}'")
+            normalized_pairs[field_name] = field_value
+
+        normalized_pairs.update(pair_kwargs)
+        return normalized_pairs
+
     @classmethod
     def INPUT_TYPES(cls):  # noqa: N802
         """Define the input types for the `CreateExtraMetaDataUniversal` node.
@@ -27,16 +67,10 @@ class CreateExtraMetaDataUniversal:
         """
         return {
             "required": {
-                "key1": ("STRING", {"default": "", "multiline": False}),
-                "value1": ("STRING", {"default": "", "multiline": False}),
+                **cls._build_pair_inputs(start_index=1, end_index=1),
             },
             "optional": {
-                "key2": ("STRING", {"default": "", "multiline": False}),
-                "value2": ("STRING", {"default": "", "multiline": False}),
-                "key3": ("STRING", {"default": "", "multiline": False}),
-                "value3": ("STRING", {"default": "", "multiline": False}),
-                "key4": ("STRING", {"default": "", "multiline": False}),
-                "value4": ("STRING", {"default": "", "multiline": False}),
+                **cls._build_pair_inputs(start_index=2, end_index=cls.EXTRA_METADATA_PAIR_COUNT),
                 "extra_metadata": ("EXTRA_METADATA",),
             },
         }
@@ -52,14 +86,8 @@ class CreateExtraMetaDataUniversal:
     def create_extra_metadata(
         self,
         extra_metadata=None,
-        key1="",
-        value1="",
-        key2="",
-        value2="",
-        key3="",
-        value3="",
-        key4="",
-        value4="",
+        *pair_args,
+        **kwargs,
     ):
         """Merge provided key/value pairs into a metadata dictionary.
 
@@ -68,16 +96,10 @@ class CreateExtraMetaDataUniversal:
         standard format for ComfyUI node outputs.
 
         Args:
-            key1 (str): The first key for the metadata.
-            value1 (str): The first value for the metadata.
             extra_metadata (dict, optional): An existing dictionary of metadata.
                 If None, a new dictionary is created. Defaults to None.
-            key2 (str, optional): The second key for the metadata. Defaults to "".
-            value2 (str, optional): The second value for the metadata. Defaults to "".
-            key3 (str, optional): The third key for the metadata. Defaults to "".
-            value3 (str, optional): The third value for the metadata. Defaults to "".
-            key4 (str, optional): The fourth key for the metadata. Defaults to "".
-            value4 (str, optional): The fourth value for the metadata. Defaults to "".
+            *pair_args: Positional ``keyN``/``valueN`` pairs kept for direct-call compatibility.
+            **kwargs: Dynamic ``keyN``/``valueN`` pairs aligned with ``INPUT_TYPES``.
 
         Returns:
             tuple: A tuple containing the updated metadata dictionary.
@@ -88,8 +110,11 @@ class CreateExtraMetaDataUniversal:
         # Copy existing metadata if provided
         if extra_metadata is not None:
             result.update(extra_metadata)
+        normalized_pairs = self._normalize_pair_arguments(pair_args, kwargs)
         # Add the new key-value pairs, only if the key is non-empty
-        for key, value in [(key1, value1), (key2, value2), (key3, value3), (key4, value4)]:
+        for index in range(1, self.EXTRA_METADATA_PAIR_COUNT + 1):
+            key = normalized_pairs.get(f"key{index}", "")
+            value = normalized_pairs.get(f"value{index}", "")
             if key:
                 result[key] = value
         return (result,)

--- a/saveimage_unimeta/nodes/extra_metadata.py
+++ b/saveimage_unimeta/nodes/extra_metadata.py
@@ -6,20 +6,40 @@ adding information that is not automatically captured by the metadata scanner.
 """
 
 
+from collections.abc import Mapping
+
+
 class CreateExtraMetaDataUniversal:
     """A node to collect key/value pairs and emit an EXTRA_METADATA payload.
 
-    This node allows users to manually input up to four key-value pairs, which
-    are then merged with an optional incoming `extra_metadata` mapping. This
-    enables the injection of custom data into the metadata pipeline without
-    modifying any configuration files.
+    This node allows users to manually input up to
+    ``EXTRA_METADATA_PAIR_COUNT`` key-value pairs, which are then merged with
+    an optional incoming ``extra_metadata`` mapping. This enables the
+    injection of custom data into the metadata pipeline without modifying any
+    configuration files.
     """
 
     EXTRA_METADATA_PAIR_COUNT = 4
 
     @classmethod
+    def _validated_pair_count(cls):
+        """Return the configured pair count after enforcing a valid minimum."""
+        pair_count = cls.EXTRA_METADATA_PAIR_COUNT
+        if not isinstance(pair_count, int) or isinstance(pair_count, bool):
+            raise TypeError(
+                "CreateExtraMetaDataUniversal.EXTRA_METADATA_PAIR_COUNT must be an integer, "
+                f"got {type(pair_count).__name__}"
+            )
+        if pair_count < 1:
+            raise ValueError(
+                f"CreateExtraMetaDataUniversal.EXTRA_METADATA_PAIR_COUNT must be >= 1, got {pair_count}"
+            )
+        return pair_count
+
+    @classmethod
     def _build_pair_inputs(cls, start_index, end_index):
         """Build the repeated key/value string inputs for the node schema."""
+        cls._validated_pair_count()
         pair_inputs = {}
         for index in range(start_index, end_index + 1):
             pair_inputs[f"key{index}"] = ("STRING", {"default": "", "multiline": False})
@@ -30,7 +50,7 @@ class CreateExtraMetaDataUniversal:
     def _pair_field_names(cls):
         """Return the ordered field names matching the declared key/value inputs."""
         field_names = []
-        for index in range(1, cls.EXTRA_METADATA_PAIR_COUNT + 1):
+        for index in range(1, cls._validated_pair_count() + 1):
             field_names.extend((f"key{index}", f"value{index}"))
         return tuple(field_names)
 
@@ -60,7 +80,8 @@ class CreateExtraMetaDataUniversal:
         """Define the input types for the `CreateExtraMetaDataUniversal` node.
 
         This method specifies the required and optional inputs for the node,
-        including four key-value pairs and an optional `extra_metadata` input.
+        including a configurable number of key-value pairs plus an optional
+        ``extra_metadata`` input.
 
         Returns:
             dict: A dictionary defining the input schema for the node.
@@ -80,7 +101,7 @@ class CreateExtraMetaDataUniversal:
     CATEGORY = "SaveImageWithMetaDataUniversal"
     DESCRIPTION = (
         "Manually create extra metadata key-value pairs to include in saved images.\n"
-        "Keys and values should be strings.\nKeys without values will be ignored and vice versa."
+        "Keys and values should be strings.\nPairs with empty keys or empty values are ignored."
     )
 
     def create_extra_metadata(
@@ -109,12 +130,18 @@ class CreateExtraMetaDataUniversal:
         result = {}
         # Copy existing metadata if provided
         if extra_metadata is not None:
+            if not isinstance(extra_metadata, Mapping):
+                raise TypeError(
+                    "CreateExtraMetaDataUniversal.extra_metadata must be a mapping, "
+                    f"got {type(extra_metadata).__name__}"
+                )
             result.update(extra_metadata)
         normalized_pairs = self._normalize_pair_arguments(pair_args, kwargs)
+        pair_count = self._validated_pair_count()
         # Add the new key-value pairs, only if the key is non-empty
-        for index in range(1, self.EXTRA_METADATA_PAIR_COUNT + 1):
+        for index in range(1, pair_count + 1):
             key = normalized_pairs.get(f"key{index}", "")
             value = normalized_pairs.get(f"value{index}", "")
-            if key:
+            if key and value is not None and value != "":
                 result[key] = value
         return (result,)

--- a/saveimage_unimeta/nodes/extra_metadata.py
+++ b/saveimage_unimeta/nodes/extra_metadata.py
@@ -7,6 +7,7 @@ adding information that is not automatically captured by the metadata scanner.
 
 
 from collections.abc import Mapping
+from typing import Any
 
 
 class CreateExtraMetaDataUniversal:
@@ -22,7 +23,7 @@ class CreateExtraMetaDataUniversal:
     EXTRA_METADATA_PAIR_COUNT = 4
 
     @classmethod
-    def _validated_pair_count(cls):
+    def _validated_pair_count(cls) -> int:
         """Return the configured pair count after enforcing a valid minimum."""
         pair_count = cls.EXTRA_METADATA_PAIR_COUNT
         if not isinstance(pair_count, int) or isinstance(pair_count, bool):
@@ -37,7 +38,7 @@ class CreateExtraMetaDataUniversal:
         return pair_count
 
     @classmethod
-    def _build_pair_inputs(cls, start_index, end_index):
+    def _build_pair_inputs(cls, start_index: int, end_index: int) -> dict[str, tuple[str, dict[str, Any]]]:
         """Build the repeated key/value string inputs for the node schema."""
         cls._validated_pair_count()
         pair_inputs = {}
@@ -47,7 +48,7 @@ class CreateExtraMetaDataUniversal:
         return pair_inputs
 
     @classmethod
-    def _pair_field_names(cls):
+    def _pair_field_names(cls) -> tuple[str, ...]:
         """Return the ordered field names matching the declared key/value inputs."""
         field_names = []
         for index in range(1, cls._validated_pair_count() + 1):
@@ -55,7 +56,7 @@ class CreateExtraMetaDataUniversal:
         return tuple(field_names)
 
     @classmethod
-    def _normalize_pair_arguments(cls, pair_args, pair_kwargs):
+    def _normalize_pair_arguments(cls, pair_args: tuple[Any, ...], pair_kwargs: dict[str, Any]) -> dict[str, Any]:
         """Normalize positional and keyword pair inputs into a validated mapping."""
         field_names = cls._pair_field_names()
         if len(pair_args) > len(field_names):
@@ -101,15 +102,15 @@ class CreateExtraMetaDataUniversal:
     CATEGORY = "SaveImageWithMetaDataUniversal"
     DESCRIPTION = (
         "Manually create extra metadata key-value pairs to include in saved images.\n"
-        "Keys and values should be strings.\nPairs with empty keys or empty values are ignored."
+        "Keys and values are expected to be strings.\nPairs with empty keys or values equal to None or '' are ignored."
     )
 
     def create_extra_metadata(
         self,
-        extra_metadata=None,
-        *pair_args,
-        **kwargs,
-    ):
+        extra_metadata: Mapping[Any, Any] | None = None,
+        *pair_args: Any,
+        **kwargs: Any,
+    ) -> tuple[dict[Any, Any]]:
         """Merge provided key/value pairs into a metadata dictionary.
 
         This method combines the input key-value pairs with an optional existing
@@ -117,17 +118,19 @@ class CreateExtraMetaDataUniversal:
         standard format for ComfyUI node outputs.
 
         Args:
-            extra_metadata (dict, optional): An existing dictionary of metadata.
-                If None, a new dictionary is created. Defaults to None.
-            *pair_args: Positional ``keyN``/``valueN`` pairs kept for direct-call compatibility.
+            extra_metadata (Mapping[Any, Any] | None, optional): An existing
+                metadata mapping. If None, a new dictionary is created.
+                Defaults to None.
+            *pair_args: Positional ``keyN``/``valueN`` pairs for direct Python
+                callers after the optional ``extra_metadata`` argument.
             **kwargs: Dynamic ``keyN``/``valueN`` pairs aligned with ``INPUT_TYPES``.
 
         Returns:
-            tuple: A tuple containing the updated metadata dictionary.
+            tuple[dict[Any, Any]]: A tuple containing the updated metadata dictionary.
         """
-        # Create a new dictionary to avoid mutating the input and to prevent
-        # stale cache issues from mutable default arguments
-        result = {}
+        # Create a fresh dictionary so incoming metadata mappings are copied
+        # rather than mutated in place.
+        result: dict[Any, Any] = {}
         # Copy existing metadata if provided
         if extra_metadata is not None:
             if not isinstance(extra_metadata, Mapping):
@@ -138,7 +141,7 @@ class CreateExtraMetaDataUniversal:
             result.update(extra_metadata)
         normalized_pairs = self._normalize_pair_arguments(pair_args, kwargs)
         pair_count = self._validated_pair_count()
-        # Add the new key-value pairs, only if the key is non-empty
+        # Add key/value pairs only when the key is truthy and the value is neither None nor an empty string.
         for index in range(1, pair_count + 1):
             key = normalized_pairs.get(f"key{index}", "")
             value = normalized_pairs.get(f"value{index}", "")

--- a/tests/test_extra_metadata.py
+++ b/tests/test_extra_metadata.py
@@ -14,6 +14,42 @@ os.environ["METADATA_TEST_MODE"] = "1"
 from saveimage_unimeta.nodes.extra_metadata import CreateExtraMetaDataUniversal
 
 
+class TestExtraMetadataInputTypes:
+    """Tests that INPUT_TYPES and runtime pair handling share one source of truth."""
+
+    def test_pair_count_drives_schema_and_runtime(self, monkeypatch):
+        """Changing the pair-count constant should update both schema and merge behavior."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", 5)
+
+        input_types = CreateExtraMetaDataUniversal.INPUT_TYPES()
+
+        assert "key1" in input_types["required"]
+        assert "value1" in input_types["required"]
+        assert "key5" in input_types["optional"]
+        assert "value5" in input_types["optional"]
+
+        metadata = CreateExtraMetaDataUniversal().create_extra_metadata(key5="Medium", value5="Oil")[0]
+
+        assert metadata == {"Medium": "Oil"}
+
+    def test_positional_arguments_remain_supported(self):
+        """Direct Python callers should still be able to pass positional key/value pairs."""
+        metadata = CreateExtraMetaDataUniversal().create_extra_metadata(None, "Artist", "Alice")[0]
+
+        assert metadata == {"Artist": "Alice"}
+
+    def test_unexpected_keyword_arguments_raise_type_error(self):
+        """Typos in key/value field names should fail fast instead of being ignored."""
+        node = CreateExtraMetaDataUniversal()
+
+        try:
+            node.create_extra_metadata(valeu1="Alice")
+        except TypeError as exc:
+            assert "Unexpected metadata arguments" in str(exc)
+        else:
+            raise AssertionError("Expected TypeError for unexpected metadata argument")
+
+
 class TestExtraMetadataNoStaleCache:
     """Tests to ensure no stale cache issue from mutable default arguments."""
 

--- a/tests/test_extra_metadata.py
+++ b/tests/test_extra_metadata.py
@@ -11,6 +11,8 @@ import os
 
 os.environ["METADATA_TEST_MODE"] = "1"
 
+import pytest
+
 from saveimage_unimeta.nodes.extra_metadata import CreateExtraMetaDataUniversal
 
 
@@ -42,12 +44,68 @@ class TestExtraMetadataInputTypes:
         """Typos in key/value field names should fail fast instead of being ignored."""
         node = CreateExtraMetaDataUniversal()
 
-        try:
+        with pytest.raises(TypeError, match="Unexpected metadata arguments"):
             node.create_extra_metadata(valeu1="Alice")
-        except TypeError as exc:
-            assert "Unexpected metadata arguments" in str(exc)
-        else:
-            raise AssertionError("Expected TypeError for unexpected metadata argument")
+
+    def test_pair_count_must_be_positive_for_input_types(self, monkeypatch):
+        """Schema generation should fail fast on invalid pair counts."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", 0)
+
+        with pytest.raises(ValueError, match="EXTRA_METADATA_PAIR_COUNT must be >= 1"):
+            CreateExtraMetaDataUniversal.INPUT_TYPES()
+
+    def test_pair_count_must_be_positive_at_runtime(self, monkeypatch):
+        """Direct runtime calls should also fail fast on invalid pair counts."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", 0)
+
+        with pytest.raises(ValueError, match="EXTRA_METADATA_PAIR_COUNT must be >= 1"):
+            CreateExtraMetaDataUniversal().create_extra_metadata(key1="Artist", value1="Alice")
+
+    def test_pair_count_must_be_an_integer_for_input_types(self, monkeypatch):
+        """Schema generation should reject non-integer pair counts clearly."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", 1.5)
+
+        with pytest.raises(TypeError, match="EXTRA_METADATA_PAIR_COUNT must be an integer"):
+            CreateExtraMetaDataUniversal.INPUT_TYPES()
+
+    def test_pair_count_must_be_an_integer_at_runtime(self, monkeypatch):
+        """Direct runtime calls should reject non-integer pair counts clearly."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", "4")
+
+        with pytest.raises(TypeError, match="EXTRA_METADATA_PAIR_COUNT must be an integer"):
+            CreateExtraMetaDataUniversal().create_extra_metadata(key1="Artist", value1="Alice")
+
+    def test_pair_count_bool_is_rejected(self, monkeypatch):
+        """Boolean values should not be accepted as integer pair counts."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", True)
+
+        with pytest.raises(TypeError, match="EXTRA_METADATA_PAIR_COUNT must be an integer"):
+            CreateExtraMetaDataUniversal.INPUT_TYPES()
+
+    def test_pair_count_of_one_remains_valid(self, monkeypatch):
+        """The minimum supported pair count should still produce a usable schema."""
+        monkeypatch.setattr(CreateExtraMetaDataUniversal, "EXTRA_METADATA_PAIR_COUNT", 1)
+
+        input_types = CreateExtraMetaDataUniversal.INPUT_TYPES()
+        metadata = CreateExtraMetaDataUniversal().create_extra_metadata(key1="Artist", value1="Alice")[0]
+
+        assert set(input_types["required"]) == {"key1", "value1"}
+        assert input_types["optional"] == {"extra_metadata": ("EXTRA_METADATA",)}
+        assert metadata == {"Artist": "Alice"}
+
+    def test_duplicate_positional_and_keyword_arguments_raise_type_error(self):
+        """Overlapping positional and keyword fields should fail fast."""
+        node = CreateExtraMetaDataUniversal()
+
+        with pytest.raises(TypeError, match="Got multiple values for argument 'key1'"):
+            node.create_extra_metadata(None, "Artist", key1="Author")
+
+    def test_invalid_extra_metadata_argument_raises_type_error(self):
+        """extra_metadata should be validated before attempting to merge it."""
+        node = CreateExtraMetaDataUniversal()
+
+        with pytest.raises(TypeError, match="extra_metadata must be a mapping"):
+            node.create_extra_metadata("not-a-mapping", key1="Artist", value1="Alice")
 
 
 class TestExtraMetadataNoStaleCache:
@@ -222,6 +280,18 @@ class TestExtraMetadataEmptyKeys:
         assert "" not in metadata
         # Values for empty keys should not appear
         assert len(metadata) == 2
+
+    def test_empty_values_ignored_when_key_present(self):
+        """Verify empty string values are skipped even when the corresponding key is present."""
+        node = CreateExtraMetaDataUniversal()
+
+        result = node.create_extra_metadata(
+            key1="Artist",
+            value1="",
+        )
+        metadata = result[0]
+
+        assert "Artist" not in metadata
 
     def test_all_empty_keys_returns_empty_dict(self):
         """Verify that all empty keys returns an empty dict."""


### PR DESCRIPTION
#63 Hardcoded iteration over 4 key-value pairs creates maintenance burden, which addresses #62 

This pull request refactors the `CreateExtraMetaDataUniversal` node to make the number of key/value metadata pairs configurable from a single constant, improving maintainability and reducing duplication between schema definition and runtime logic. It also introduces robust input normalization and validation, and adds tests to ensure the new behavior is correct.

**Refactor for dynamic pair count and input normalization:**

* Introduced the `EXTRA_METADATA_PAIR_COUNT` class constant and helper methods (`_build_pair_inputs`, `_pair_field_names`, `_normalize_pair_arguments`) to generate key/value input fields and validate arguments dynamically, replacing hardcoded field definitions.
* Updated the `INPUT_TYPES` method to use the new helpers, ensuring the schema automatically matches the configured pair count.
* Refactored the `create_extra_metadata` method to accept variable positional and keyword arguments, normalizing and validating them using the new helpers, and raising clear errors for unexpected or duplicate arguments. [[1]](diffhunk://#diff-03401d722c5abb76ac93ccc85c504b18e6a69a21fc677bdcf31a4a8f0198ce22L55-R90) [[2]](diffhunk://#diff-03401d722c5abb76ac93ccc85c504b18e6a69a21fc677bdcf31a4a8f0198ce22L71-R102) [[3]](diffhunk://#diff-03401d722c5abb76ac93ccc85c504b18e6a69a21fc677bdcf31a4a8f0198ce22R113-R117)

**Testing improvements:**

* Added a new test class `TestExtraMetadataInputTypes` to verify that changing the pair count updates both schema and runtime logic, positional arguments remain supported, and unexpected arguments raise errors.