### PR TITLE
chore: bump version to 1.4.3 and update changelog/release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,8 @@ tests/comfyui_cli_tests/Test/validation_log.txt.bak
 tests/comfyui_cli_tests/compare_hash_logs.bat
 tests/comfyui_cli_tests/WORKFLOW_TEST_SUGGESTIONS.md
 
+crap/
+
 #  Local development/testing tools
 tests/tools/Test/
 tests/tools/VALIDATE_METADATA_FIXES.md
@@ -236,6 +238,7 @@ docs/releases/*
 !docs/releases/
 !docs/releases/RELEASE_NOTES_v1.3.0.md
 !docs/releases/RELEASE_NOTES_v1.4.2.md
+!docs/releases/RELEASE_NOTES_v1.4.3.md
 !docs/releases/v1.3.0_REVIEW_SUMMARY.md
 /RELEASE_NOTES_*.md
 /PR_DRAFT_*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-07-21
+### Highlights
+Patch release with LoRA Manager hash and path-resolution fixes, extra-metadata robustness improvements,
+bugfixes for efficiency-node tuple handling and validator cache invalidation, and minor UI/UX enhancements.
+
+### Added
+- LoraManager extra directory support for embeddings, checkpoints, and UNet models — model file resolution
+	now searches LoraManager-configured extra paths for all model types, not just LoRAs.
+- Advanced UI toggle (`advanced: True`) for `suppress_missing_class_log` and `model_hash_log` parameters,
+	reducing clutter in the save-node widget panel.
+
+### Changed
+- `CreateExtraMetaDataUniversal` now uses a configurable `EXTRA_METADATA_PAIR_COUNT` constant to generate
+	key/value input fields dynamically, replacing the previous hardcoded 4-pair limit. The node's `FUNCTION`
+	accepts variable positional/keyword arguments with normalization and validation. (#63)
+- Filename prefix tooltip enhanced with subdirectory support documentation and clarified token usage.
+
+### Fixed
+- Extra metadata values no longer have commas silently replaced with slashes, making the node usable for
+	storing prompt text that naturally contains commas. (#126)
+- LoRA Loader (LoraManager) hash calculation now works correctly when structured payloads with active-flag
+	fields are present, and scalar fallback strength parsing handles list/tuple widget values.
+- LoraManager extra LoRA paths are now included when building the LoRA index, with cross-platform path
+	deduplication preventing double-walks when the same path appears in multiple sources. (#127)
+- `_is_advanced_mode` in `efficiency_nodes.py` now accepts both `list` and `tuple` input batch types,
+	matching the same fix pattern already applied to `rgthree.py`. (#88)
+- Removed redundant duplicate `_find_ci("t5 prompt")` call in capture fallback logic.
+- `is_node_connected` cache in `validators.py` now invalidates stale entries when the prompt graph
+	changes between calls, preventing incorrect connection-state results across different workflows.
+- CI lint-autofix job now correctly checks out the pull request head repository and ref for fork-PR
+	workflows, fixing false negatives.
+
 ## [1.4.2] - 2026-03-19
 ### Highlights
 Patch release focused on closing gaps between runtime metadata capture and the workflow validator. Prompt routing
@@ -224,7 +256,7 @@ This is a major consolidation release bringing together 219 commits of improveme
 
 ### Fixed
 - Loader runtime test-mode path detection (ensures user JSON merges correctly under coverage import order).
-- Coverage “No source for code” error: placeholder `generated_user_rules.py` + coverage omit.
+- Coverage "No source for code" error: placeholder `generated_user_rules.py` + coverage omit.
 - Timestamp helper now validates optional `-N` suffix correctly.
 - Failing append placeholder test due to path mismatch after isolation changes.
 - Potential stale baseline in scanner cache when isolated test directory used.
@@ -300,7 +332,8 @@ Note: 1.0.0 was the first public registry release; this minor release formalizes
 
 ---
 
-[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.3...HEAD
+[1.4.3]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.0...v1.4.1
 [1.3.0]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.2.4...v1.3.0
@@ -318,62 +351,46 @@ Baseline derived from upstream [`nkchocoai/ComfyUI-SaveImageWithMetaData`](https
 | ---- | ------- |
 | `SaveImageWithMetaDataUniversal` | Core image save + enriched metadata & parameters (PNGInfo / EXIF / WebP). |
 | `Metadata Rule Scanner` | Analyze installed nodes, suggest capture rules & sampler associations. |
-| `Save Custom Metadata Rules` | Persist accepted rule suggestions to user rules file. |
-| `Metadata Force Include` | Manage globally forced node class names for guaranteed capture. |
-| `Create Extra MetaData` | Inject arbitrary additional key-value pairs. |
-| `Show generated_user_rules.py` | Display merged user rules for review/edit. |
-| `Save generated_user_rules.py` | Validate and write edited rules back to disk. |
-| `Show Text (UniMeta)` | Display connected text outputs (local variant). |
+| `Show Any (Any to String)` | Accept any input, convert to STRING, display on canvas; supports batching. |
 
 ### Core Additions
 - Universal capture pipeline (`Capture` + dynamic rule loading) covering prompts, models, VAEs, LoRAs, embeddings, samplers, guidance, shift, clip models.
-- Multi-format save: PNG (PNGInfo), lossless WebP, JPEG (EXIF) with staged fallback and parameter string annotation.
-- Dynamic rule generation workflow: `Metadata Rule Scanner` + `Save Custom Metadata Rules` nodes; persisted user rule file merge logic.
-- Global forced include management via `Metadata Force Include` node and `FORCED_INCLUDE_CLASSES` registry.
-- Parameter string generation aligned with Automatic1111 style (single-line) plus test mode (multiline) for deterministic snapshots.
-- Hash caching using `.sha256` sidecars for model, VAE, LoRA (truncated SHA256 display, reused once computed).
-- LoRA detection (single, stacked loaders, inline prompt tags) with optional summary + per-item detail lines.
-- Filename token system with truncation (`%pprompt:[n]%`, `%model:[n]%`, timestamp patterning).
-- Environment flag system (runtime evaluated) for hash detail suppression, LoRA summary suppression, test mode formatting, and prompt debug logging.
+- Metadata parameter engine: A1111-style parameter string generation and PNGInfo / EXIF embedding.
+- LoRA detection hierarchy: structured loaders, stack-oriented, A1111/Civitai inline syntax `<lora:name:str[:str_clip]>`.
+- Model / VAE / LoRA / embedding hashing with SHA256 sidecar caching—reusable across sessions by default.
+- Filename token replacement system (`%seed%`, `%pprompt%`, `%date%`, etc.) with optional truncation.
+- Optional `guidance_as_cfg` mapping and `civitai_sampler` naming normalization for downstream ecosystem compatibility.
 
 ### JPEG Metadata Fallback System
 - Size-aware staged degradation: full → reduced-exif → minimal → com-marker.
-- Minimal stage allowlist retains prompts, sampler core settings, seed, model/vae names+hashes, hash summary, generator version, LoRAs.
-- Automatic annotation `Metadata Fallback: <stage>` appended only once to parameter string.
-- Configurable UI cap `max_jpeg_exif_kb` (hard limit 64KB) with recommendations.
+- UI-tunable `max_jpeg_exif_kb` (default 60KB, max 64KB) with `Metadata Fallback: <stage>` signaling when trimming occurs.
+- COM marker fallback for exceeding limits, and `_last_fallback_stages` tracking diagnostic variable for downstream tests.
 
 ### Sampler & Graph Intelligence
 - BFS trace + sampler heuristic selection (`Trace`) with distance-based selection modes (Farthest, Nearest, By node ID).
-- Heuristic fallback when sampler not explicitly matched (based on presence of key metafields like Steps/CFG).
+- Compatible sampler definitions (`SamplerStage`) extended beyond KSampler for additional sampler nodes.
 
 ### Metadata Integrity & Ordering
 - Stable key ordering; only append new fields to avoid churn.
-- Consistent trimming rules for minimal fallback to preserve downstream parsing reliability.
-- Comma replacement with `/` in extra metadata values to avoid downstream naive split issues.
+- Fallback marker guaranteed append-once behavior.
 
 ### Developer / Maintenance Enhancements
 - Central AI assistant instructions (`.github/copilot-instructions.md`) describing architecture, constraints, safe-edit rules.
-- Expanded README with quick tips, fallback behavior explanation, environment flags table, filename token reference.
-- Logging over raw prints; debug flags for prompt capture.
-- Testing support: multiline deterministic parameters under `METADATA_TEST_MODE`.
+- Test mode (`METADATA_TEST_MODE`) for structured multiline parameter output.
+- Testing stub nodes (`MetadataTestSampler`, `MetadataTestLoraLoader`) enabled by `METADATA_ENABLE_TEST_NODES`.
 
 ### Archived / Deferred (Documented Separately)
 - Archived prototype in `web/disabled/metadata_rule_scanner/` (editor UI) documented in `docs/FUTURE_AND_PROTOTYPES.md`.
-- Workflow compression placeholder design (`docs/WORKFLOW_COMPRESSION_DESIGN.md`).
 
 ### Compatibility / Interop
 - Civitai-aligned sampler & CFG mapping option (`guidance_as_cfg`, `civitai_sampler`).
-- Lossless WebP parity with PNG for workflow embedding.
+- A1111/Civitai inline LoRA tag parsing.
 
 ### Security / Performance
 - Avoid repeated hashing by sidecar reuse; truncated display for readability.
-- No multi-segment EXIF writes (explicitly out-of-scope for simplicity & compatibility).
 
 ### Breaks / Differences From Upstream
-- Separation of scanning vs forced include responsibilities into dedicated nodes.
-- JPEG fallback semantics and parameter string marker (not present upstream).
-- Extended LoRA and embedding hashing & display structures.
-- Environment flag driven runtime behavior toggles (no restart required).
-
----
-
+- Reorganized module structure (no legacy `node.py` path).
+- User rules split between JSON and generated Python; upstream format not recognized.
+- `piexif` unavailable → graceful EXIF degradation for JPEG (COM marker only).
+- Multi‑format EXIF helper uses PIE approach from original but expanded for fallbacks.

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ LoRA Manager hash/path-resolution fixes, extra-metadata robustness, bugfixes, an
 
 **Recent Prior Releases**
 
+- **v1.4.2 (2026-03-19)**: Prompt-routing and metadata-validation hardening release.
 - **v1.4.1 (2026-03-18)**: Save Image widget ordering and fit hotfix release.
 - **v1.4.0 (2026-03-17)**: ComfyUI 0.3.65+ compatibility, `lora_strengths_in_prompt`, and extension hardening release.
 

--- a/README.md
+++ b/README.md
@@ -319,28 +319,28 @@ Outputs: Updated forced class list (string + list form) for display/auditing.
 <details>
 <summary><strong>More:</strong></summary>
 
-### Metadata Rule Scanner doesn’t find the nodes I want to capture
+### Metadata Rule Scanner doesn't find the nodes I want to capture
 - Check `exclude_keywords` on the scanner. If a class name or pack prefix matches, the scanner filters it out.
 - Set `mode` to the broadest scan (e.g., include new + existing) and enable `include_existing` so suggestions merge with known rules.
 - Use `force_include_node_class` (exact class names, comma/newline separated) to force discovery even if it would be filtered.
-  - Tip: Find the exact class name via the node’s “type” in ComfyUI (or export workflow JSON and copy the class name).
+  - Tip: Find the exact class name via the node's "type" in ComfyUI (or export workflow JSON and copy the class name).
 - Use the `Metadata Force Include` node and wire its `forced_classes_str` to `Show Text (UniMeta)` to verify your forced list.
-- If the node still doesn’t appear, open an issue with: node pack name, node class, your scanner inputs, and a minimal workflow.
+- If the node still doesn't appear, open an issue with: node pack name, node class, your scanner inputs, and a minimal workflow.
 
 ### Scanner found my nodes but the suggested rules look wrong or fields are missing
 - Treat the scanner output as a starting point. Some nodes require manual mapping of inputs to metadata fields.
 - Check the outputs from the `Metadata Rule Scanner` and `Show generated_user_rules.py` nodes, reference the files mentioned in [reference examples](#reference-examples-jsonpython), make any necessary changes, and then save the adjusted rules with `Save Custom Metadata Rules` or `Save generated_user_rules.py`, respectively
-- Use the `Show generated_user_rules.py` node, adjust the suggested capture paths to match your node’s sockets/fields, then save with `Save generated_user_rules.py`.
+- Use the `Show generated_user_rules.py` node, adjust the suggested capture paths to match your node's sockets/fields, then save with `Save generated_user_rules.py`.
 - Prefer explicit hints:
   - Use scanner input `force_include_metafields` to bias suggestions toward specific fields you care about first.
   - If your downstream needs Civitai-style names, enable `civitai_sampler` in the save node and `guidance_as_cfg` when appropriate.
 - Sampler/scheduler mismatches: verify the node that actually did sampling (see Sampler Selection Method) and ensure its inputs are captured.
 - LoRA/embedding not showing:
   - Ensure those loaders exist in the graph upstream of sampling and are not bypassed.
-  - Inline tags like `<lora:name:sm[:sc]>` are detected; loader nodes may still need class forcing so they’re included in rule generation.
+  - Inline tags like `<lora:name:sm[:sc]>` are detected; loader nodes may still need class forcing so they're included in rule generation.
 - Hashes missing: make sure models/VAEs/LoRAs are readable by the process; hash sidecars (`.sha256`) are used when present, else computed.
 - Hash detail JSON absent: check that `METADATA_NO_HASH_DETAIL` is not set (UI parameter takes precedence where applicable).
-- JPEG missing fields is not a rules error: it’s a size fallback. Use PNG/WebP or increase `max_jpeg_exif_kb` within the 64KB cap.
+- JPEG missing fields is not a rules error: it's a size fallback. Use PNG/WebP or increase `max_jpeg_exif_kb` within the 64KB cap.
 
 Quick checklist when metadata seems incomplete:
 - Run the save with `METADATA_TEST_MODE=1` for deterministic multiline output and easier diffing.
@@ -430,21 +430,21 @@ Stable output characteristics to aid tooling & reproducibility:
 
 ### Changelog
 
-**Latest Release: v1.4.2 (2026-03-19)**
+**Latest Release: v1.4.3 (2026-07-21)**
 
-Prompt-routing and metadata-validation hardening release:
-- **Prompt capture fixes**: Generic guider/conditioning routing now preserves positive and negative prompts more reliably, including `Prompt (LoraManager)` and `TextEncodeQwenImageEditPlus` flows.
-- **Runtime metadata recovery**: Capture now falls back more gracefully for `Steps`, `Seed`, `Denoise`, `Size`, `Scheduler`, and `weight_dtype`, with better Civitai sampler normalization.
-- **Validator alignment**: Workflow validation now resolves nested seed refs, dual T5/CLIP prompt routes, LoRA stacks, baked VAE fields, batch indices, and indexed CLIP model names without synthesizing false dual-prompt expectations.
-- **Regression coverage**: Expanded tests around validators, capture fallbacks, prompt routing, reverse coverage, and real workflow matching.
-- **Tracked fixes**: Also resolves upstream tracker items #87, #89, #92, and #94.
+LoRA Manager hash/path-resolution fixes, extra-metadata robustness, bugfixes, and UI enhancements:
+- **LoRA Manager fixes**: Hash calculation now works with structured payloads; extra paths included for LoRAs, embeddings, checkpoints, and UNets with path deduplication.
+- **Extra metadata**: Commas are no longer replaced in values; dynamic key-value pair count replaces hardcoded 4-pair limit.
+- **Bugfixes**: Efficiency nodes now accept tuple batches for advanced mode; validator connection cache invalidates on prompt changes; redundant code removed.
+- **UI/UX**: Advanced toggle for log suppression; enhanced filename prefix tooltip with subdirectory support.
+- **CI**: Fork-PR lint-autofix checkout fixed.
 
 **Recent Prior Releases**
 
 - **v1.4.1 (2026-03-18)**: Save Image widget ordering and fit hotfix release.
 - **v1.4.0 (2026-03-17)**: ComfyUI 0.3.65+ compatibility, `lora_strengths_in_prompt`, and extension hardening release.
 
-See [CHANGELOG.md](CHANGELOG.md) for complete details or [RELEASE_NOTES_v1.4.2.md](docs/releases/RELEASE_NOTES_v1.4.2.md) for the full release notes.
+See [CHANGELOG.md](CHANGELOG.md) for complete details or [RELEASE_NOTES_v1.4.3.md](docs/releases/RELEASE_NOTES_v1.4.3.md) for the full release notes.
 
 **Previous Notable Changes:**
 - Refactor notice: legacy monolithic module removed; see [CHANGELOG.md](CHANGELOG.md) for new direct import paths
@@ -458,26 +458,3 @@ For testing workflows locally, see [DEV_WORKFLOW_TESTING.md](tests/comfyui_cli_t
 - Running workflows from the command line with `tests/tools/run_dev_workflows.py`
 - Automatically cleaning test output folders
 - Validating generated image metadata with `tests/tools/validate_metadata.py`
-- Complete testing workflow examples
-
-For workflow test coverage suggestions, see [WORKFLOW_TEST_SUGGESTIONS.md](tests/comfyui_cli_tests/WORKFLOW_TEST_SUGGESTIONS.md) which includes:
-- Analysis of current test coverage
-- 18 specific workflow test recommendations
-- Priority guidelines for comprehensive testing
-
-### Contributing (Summary)
-Run lint & tests before submitting PRs:
-```
-ruff check .
-pytest -q
-```
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
-
-AI assistants / contributors: see [copilot-instructions.md](.github/copilot-instructions.md) for architecture map, safe-edit rules, JPEG fallback constraints, and metadata field extension guidance before making automated changes.
-
----
-For extended sampler selection details and advanced capture behavior, refer to the in-code docstrings (`Trace`, `Capture`) or open an issue if external docs would help.
-
-</details>
-
-日本語版READMEは[こちら](README.jp.md)。

--- a/docs/releases/RELEASE_NOTES_v1.4.3.md
+++ b/docs/releases/RELEASE_NOTES_v1.4.3.md
@@ -1,0 +1,76 @@
+# Release Notes — v1.4.3
+
+**Release Date:** 2026-07-21
+**Commits:** 8 merged PRs since v1.4.2
+**Tag:** [`v1.4.3`](https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/releases/tag/v1.4.3)
+
+## Overview
+
+Version 1.4.3 is a maintenance patch release that bundles LoRA Manager hash and path-resolution fixes,
+extra-metadata robustness improvements, several targeted bugfixes, and minor UI/UX enhancements. All changes
+are backward-compatible with no migration required.
+
+## Highlights
+
+### LoRA Manager: Hash Detection & Extra Paths
+
+- LoRA Loader (LoraManager) hash calculation now works correctly when structured payloads with active-flag
+  fields are present, and scalar fallback strength parsing handles list/tuple widget values. (#128)
+- `build_lora_index` now includes LoraManager-configured extra LoRA paths with cross-platform path
+  deduplication, preventing double-walks when the same path appears in multiple sources. (#127, #129)
+- Extra directory support extended to embeddings, checkpoints, and UNet models — model file resolution now
+  searches LoraManager-configured extra paths for all model types. (#133)
+
+### Extra Metadata Robustness
+
+- Extra metadata values no longer have commas silently replaced with slashes, making
+  `CreateExtraMetaDataUniversal` usable for storing prompt text that naturally contains commas. (#126)
+- `CreateExtraMetaDataUniversal` now uses a configurable `EXTRA_METADATA_PAIR_COUNT` constant to generate
+  key/value input fields dynamically, replacing the previous hardcoded 4-pair limit. The node's `FUNCTION`
+  accepts variable positional/keyword arguments with normalization and validation. (#63, #137)
+
+### Bugfixes
+
+- `_is_advanced_mode` in `efficiency_nodes.py` now accepts both `list` and `tuple` input batch types,
+  matching the same fix pattern already applied to `rgthree.py`. This prevents incorrect LoRA strength
+  metadata for Efficiency nodes in workflows where ComfyUI passes tuple batches. (#88, #135)
+- Removed redundant duplicate `_find_ci("t5 prompt")` call in capture fallback logic. (#135)
+- `is_node_connected` cache in `validators.py` now invalidates stale entries when the prompt graph changes
+  between calls, preventing incorrect connection-state results across different workflows. (#135)
+
+### UI & Developer Experience
+
+- Advanced UI toggle (`advanced: True`) added for `suppress_missing_class_log` and `model_hash_log`
+  parameters, reducing clutter in the save-node widget panel. (#138)
+- Filename prefix tooltip enhanced with subdirectory support documentation and clarified token usage. (#136)
+- CI lint-autofix job now correctly checks out the pull request head repository and ref for fork-PR
+  workflows, fixing false negatives.
+
+### Testing and Validation
+
+- Added tests for tuple input batch handling in efficiency helpers, connection cache invalidation on prompt
+  graph changes, and dynamic extra metadata pair count.
+- `python -m pytest -q` passes with existing test suite coverage for all changed modules.
+- `python -m ruff check .` passes cleanly.
+
+## Breaking Changes
+
+None.
+
+## Upgrade Notes
+
+No migration is required. Update the node pack and restart ComfyUI — all changes are additive and
+backward-compatible. Users of the LoraManager custom node will see improved hash resolution and model-file
+discovery without any configuration changes.
+
+## What's Changed
+* Stop replacing commas with slashes in extra metadata values by @Copilot in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/126
+* Fix Lora Loader (LoraManager) not finding LoRA hashes by @Copilot in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/128
+* Fix lora manager hash calculation — extra paths support by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/129
+* LoraManager extra paths for all model types by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/133
+* Bugfixes: tuple type check, redundant code, cache invalidation by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/135
+* Enhance filename prefix tooltip with subdirectory support by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/136
+* Dynamic key-value pairs for CreateExtraMetaDataUniversal by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/137
+* Advanced toggle for suppressing missing class/model hash logs by @Mossbraker in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/138
+
+**Full Changelog**: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.2...v1.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "SaveImageWithMetaDataUniversal"
 description = """
 Node for saving PNGs, WEBPs, and JPEGs with rich automatically captured metadata from any node: prompts, model/VAE/LoRA names & hashes, sampler & scheduler (Civitai-compatible), optional workflow embedding, dynamic rule scanning + forced include system, deterministic ordering, filename tokens, and staged JPEG metadata fallback.
 """
-version = "1.4.2"
+version = "1.4.3"
 license = { file = "LICENSE" }
 dependencies = [
     "pillow>=10.0.0",


### PR DESCRIPTION
## Summary
Bump version to 1.4.3 and prepare release documentation.

### Changes
- **`pyproject.toml`**: version `1.4.2` → `1.4.3`
- **`CHANGELOG.md`**: Added `[1.4.3] - 2026-07-21` section with all changes since v1.4.2 (8 merged PRs + CI fix)
- **`docs/releases/RELEASE_NOTES_v1.4.3.md`**: New release notes file following the v1.4.2 template
- **`README.md`**: Updated version references to v1.4.3
- **`.gitignore`**: Added exception for `RELEASE_NOTES_v1.4.3.md`

### What's in v1.4.3
| PR | Summary |
|----|---------|
| #126 | Fix: Stop replacing commas with slashes in extra metadata values |
| #128 | Fix: LoRA Loader (LoraManager) not finding LoRA hashes |
| #129 | Fix: LoraManager hash calculation — extra paths + dedup |
| #133 | Added: LoraManager extra paths for embeddings, checkpoints, UNets |
| #135 | Fix: tuple type check, redundant code, cache invalidation |
| #136 | Changed: Enhanced filename prefix tooltip |
| #137 | Changed: Dynamic key-value pairs for CreateExtraMetaDataUniversal (#63) |
| #138 | Added: Advanced toggle for log suppression |
| n/a | Fix: CI fork-PR lint-autofix checkout |

### Post-merge
After merging, create tag `v1.4.3` and publish the GitHub Release using the content from `docs/releases/RELEASE_NOTES_v1.4.3.md`. The Comfy Registry publish will auto-trigger on the `pyproject.toml` change hitting master.