### PR TITLE
Include creation time in PNG metadata

### DIFF
--- a/saveimage_unimeta/nodes/save_image.py
+++ b/saveimage_unimeta/nodes/save_image.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+from email.utils import formatdate
 from datetime import datetime
 
 # Attempt to import ComfyUI's folder_paths; provide a lightweight fallback stub when
@@ -533,6 +534,8 @@ class SaveImageWithMetaDataUniversal:
                         if not save_workflow_image and x == "workflow":
                             continue
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                creation_time = formatdate(timeval=None, localtime=False, usegmt=True)
+                metadata.add_text("Creation Time", creation_time)
 
             filename_prefix = self.format_filename(filename_prefix, pnginfo_dict)
             output_path = os.path.join(self.output_dir, filename_prefix)


### PR DESCRIPTION
For image management purposes, I have found it useful to store the creation timestamp for an image using the standard PNG Creation Time text chunk. The details for this text chunk are in section 4.2.3 of this document: https://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html. I implemented it to that spec. It's a small change, but for full disclosure, I did use Copilot to assist with making the change. All ruff and pytest checks pass. Let me know if you'd like any changes. Thanks for the work on this node pack!