### PR TITLE
fix: skip V3 subgraph dict links in graph tracers

### DIFF
--- a/saveimage_unimeta/defs/validators.py
+++ b/saveimage_unimeta/defs/validators.py
@@ -121,7 +121,9 @@ def _get_node_id_list(prompt, field_name):
             d = deque()
             visited = set()
             if field_name in field_map and field_map[field_name] in node["inputs"]:
-                d.append(node["inputs"][field_map[field_name]][0])
+                inp = node["inputs"][field_map[field_name]]
+                if _is_link_input(inp):
+                    d.append(inp[0])
             while len(d) > 0:
                 current_node_id = d.popleft()
                 if current_node_id not in prompt or current_node_id in visited:

--- a/saveimage_unimeta/trace.py
+++ b/saveimage_unimeta/trace.py
@@ -84,6 +84,11 @@ class Trace:
             for value in input_fields.values():
                 if isinstance(value, list):
                     nid = value[0]
+                    if not isinstance(nid, str):
+                        # V3/subgraph links reference nodes as dicts (or other
+                        # non-string ids) and are not traceable in the flat prompt
+                        # graph, so skip them rather than crashing on hashing.
+                        continue
                     if nid not in visited and nid in prompt:  # Ensure the node is not visited and exists
                         class_type = prompt[nid]["class_type"]
                         trace_tree[nid] = TraceEntry(distance + 1, class_type)

--- a/saveimage_unimeta/trace.py
+++ b/saveimage_unimeta/trace.py
@@ -17,6 +17,7 @@ from .defs import CAPTURE_FIELD_LIST
 from .defs.combo import SAMPLER_SELECTION_METHOD
 from .defs.meta import MetaField
 from .defs.samplers import SAMPLERS
+from .defs.validators import _is_link_input
 
 from .utils.color import cstr
 
@@ -82,13 +83,8 @@ class Trace:
             current_node_id, distance = node_queue.popleft()
             input_fields = prompt[current_node_id]["inputs"]
             for value in input_fields.values():
-                if isinstance(value, list):
+                if _is_link_input(value):
                     nid = value[0]
-                    if not isinstance(nid, str):
-                        # V3/subgraph links reference nodes as dicts (or other
-                        # non-string ids) and are not traceable in the flat prompt
-                        # graph, so skip them rather than crashing on hashing.
-                        continue
                     if nid not in visited and nid in prompt:  # Ensure the node is not visited and exists
                         class_type = prompt[nid]["class_type"]
                         trace_tree[nid] = TraceEntry(distance + 1, class_type)

--- a/tests/test_defs_validators.py
+++ b/tests/test_defs_validators.py
@@ -49,14 +49,14 @@ def test_is_positive_prompt_detects_known_text_encoder():
     assert not validators_mod.is_positive_prompt("1", None, prompt, None, None, None)
 
 
-# A sampler whose conditioning input references a V3 subgraph (dict link) must be
-# skipped safely instead of raising TypeError: unhashable type: 'dict'.
-def test_positive_prompt_skips_subgraph_dict_links():
+# A list-of-dicts widget value (e.g. a LoRA stack) is not a link and must not
+# raise TypeError: unhashable type: 'dict'.
+def test_positive_prompt_skips_list_of_dicts_inputs():
     prompt = {
         "1": {
             "class_type": "KSampler",
             "inputs": {
-                "positive": [{"subgraph": "abc-123", "output": 0}, 0],
+                "positive": [{"name": "foo.safetensors", "strength": 0.5}],
             },
         },
     }

--- a/tests/test_defs_validators.py
+++ b/tests/test_defs_validators.py
@@ -49,6 +49,22 @@ def test_is_positive_prompt_detects_known_text_encoder():
     assert not validators_mod.is_positive_prompt("1", None, prompt, None, None, None)
 
 
+# A sampler whose conditioning input references a V3 subgraph (dict link) must be
+# skipped safely instead of raising TypeError: unhashable type: 'dict'.
+def test_positive_prompt_skips_subgraph_dict_links():
+    prompt = {
+        "1": {
+            "class_type": "KSampler",
+            "inputs": {
+                "positive": [{"subgraph": "abc-123", "output": 0}, 0],
+            },
+        },
+    }
+
+    assert not validators_mod.is_positive_prompt("1", None, prompt, None, None, None)
+    assert not validators_mod.is_negative_prompt("1", None, prompt, None, None, None)
+
+
 # Negative prompt validator must traverse intermediate nodes and match regex-based encoders.
 def test_is_negative_prompt_handles_regex_encoder_and_chains():
     prompt = {

--- a/tests/test_trace_extended.py
+++ b/tests/test_trace_extended.py
@@ -184,6 +184,28 @@ class TestTraceBFS:
         assert "a" in result
         assert "b" in result
 
+    def test_trace_skips_subgraph_dict_links(self, trace_module):
+        """V3 subgraph links (first element is a dict) must not crash BFS traversal."""
+        # Under the ComfyUI V3 schema, an input connected through a subgraph is
+        # serialised with a dict node reference instead of a string id.
+        prompt = {
+            "save": {
+                "class_type": "SaveNode",
+                "inputs": {
+                    "img": ["sampler", 0],
+                    "subgraph_out": [{"subgraph": "abc-123", "output": 0}, 0],
+                },
+            },
+            "sampler": {"class_type": "KSampler", "inputs": {}},
+        }
+
+        result = trace_module.Trace.trace("save", prompt)
+
+        # The dict link is not traceable in the flat prompt graph and is skipped.
+        assert result["save"].distance == 0
+        assert result["sampler"].distance == 1
+        assert len(result) == 2
+
 
 class TestFindSamplerNodeId:
     """Tests for Trace.find_sampler_node_id."""

--- a/tests/test_trace_extended.py
+++ b/tests/test_trace_extended.py
@@ -184,16 +184,16 @@ class TestTraceBFS:
         assert "a" in result
         assert "b" in result
 
-    def test_trace_skips_subgraph_dict_links(self, trace_module):
-        """V3 subgraph links (first element is a dict) must not crash BFS traversal."""
-        # Under the ComfyUI V3 schema, an input connected through a subgraph is
-        # serialised with a dict node reference instead of a string id.
+    def test_trace_skips_list_of_dicts_inputs(self, trace_module):
+        """List-of-dicts widget values (e.g. LoRA stacks) must not crash BFS traversal."""
+        # A LoRA stack widget value is a list of dicts, not a [node_id, output_index]
+        # link. Trace.trace must skip it rather than hashing the dict.
         prompt = {
             "save": {
                 "class_type": "SaveNode",
                 "inputs": {
                     "img": ["sampler", 0],
-                    "subgraph_out": [{"subgraph": "abc-123", "output": 0}, 0],
+                    "lora_stack": [{"name": "foo.safetensors", "strength": 0.5}],
                 },
             },
             "sampler": {"class_type": "KSampler", "inputs": {}},
@@ -201,7 +201,7 @@ class TestTraceBFS:
 
         result = trace_module.Trace.trace("save", prompt)
 
-        # The dict link is not traceable in the flat prompt graph and is skipped.
+        # The list-of-dicts value is not a link and is skipped.
         assert result["save"].distance == 0
         assert result["sampler"].distance == 1
         assert len(result) == 2


### PR DESCRIPTION
## Problem

Saving an image can crash with `TypeError: unhashable type: 'dict'` at
`saveimage_unimeta/trace.py` (`Trace.trace`), where `nid = value[0]` resolves
to a `dict` and `nid not in visited` (a `set`) is evaluated.

Reproducible on ComfyUI 0.34.0 when a node whose inputs include a list-of-dicts
widget value (for example, a LoRA stack like
`[{"name": "foo.safetensors", "strength": 0.5}]`) sits upstream of the Save
node.

## Root cause

`Trace.trace` (and `validators._get_node_id_list`) assumed every list-valued
input is a graph link of the form `[node_id, output_index]` with a **string**
`node_id`. But ComfyUI widget values that are lists of dictionaries are not
links:

- The frontend submits such values wrapped as `{"__value__": [...]}` (to
  disambiguate them from links).
- ComfyUI's prompt validation unwraps them back to a bare list (`execution.py`),
  so the tracer sees `[{"name": ..., "strength": ...}, ...]`.

`Trace.trace` then did `nid = value[0]`, yielding a `dict`, and hashing it in
`nid not in visited` raised `TypeError: unhashable type: 'dict'`.
`validators._get_node_id_list` had the same blind `[0]` indexing on its initial
sampler conditioning link.

## Fix

Use the existing shared `_is_link_input` predicate (already used by
`validators.py`) instead of an ad-hoc `isinstance(value, list)` check, so
non-link list values are skipped rather than hashed:

- `saveimage_unimeta/trace.py`: replace `if isinstance(value, list):` with
  `if _is_link_input(value):` in `Trace.trace`.
- `saveimage_unimeta/defs/validators.py`: wrap the initial conditioning-link
  append with `_is_link_input` in `_get_node_id_list`.

`_is_link_input` requires a two-element `[node_id, output_index]` where
`node_id` is `str | int` and `output_index` is `int`, so list-of-dicts widget
values are correctly ignored. This also fixes a latent `IndexError` on
empty-list inputs and aligns the two tracers on a single definition of "link".

## Scope note

Other `value[0]` / `[0]` indexing sites (`capture.py`, `defs/selectors.py`,
`defs/ext/*`) were reviewed and either already guard against non-link values or
operate on resolved `get_input_data` output rather than raw prompt links, so
they were left untouched.

## Testing

- Added regression tests in `tests/test_trace_extended.py` and
  `tests/test_defs_validators.py` that feed a bare list-of-dicts input
  (a LoRA-stack-shaped value) through the tracer and assert it is skipped
  without crashing.
- Confirmed the new tests fail with `TypeError: unhashable type: 'dict'` on the
  unpatched code and pass after the fix.
- `pytest -q tests/test_trace_extended.py tests/test_defs_validators.py tests/test_trace.py`: 62 passed.
- `ruff check` on the changed files: clean.