### PR TITLE
chore: bump version to 1.4.4 and update changelog/release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-09-03
+### Highlights
+Patch release fixing a metadata capture crash (`TypeError: unhashable type: 'dict'`) when a list-of-dicts
+widget value (such as a LoRA stack) appears upstream of the save node.
+
+### Fixed
+- `Trace.trace` now uses the shared `_is_link_input` predicate instead of assuming every list-valued input
+	is a graph link, preventing a `TypeError: unhashable type: 'dict'` crash on list-of-dicts widget values
+	(e.g. LoRA stacks). This also fixes a latent `IndexError` on empty-list inputs and aligns `trace.py`
+	with `validators.py`. (#145)
+- `_get_node_id_list` in `validators.py` guards its initial sampler conditioning link with `_is_link_input`,
+	so non-link values are skipped instead of indexed blindly. (#145)
+
 ## [1.4.3] - 2026-07-21
 ### Highlights
 Patch release with LoRA Manager hash and path-resolution fixes, extra-metadata robustness improvements,
@@ -332,7 +345,8 @@ Note: 1.0.0 was the first public registry release; this minor release formalizes
 
 ---
 
-[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.4...HEAD
+[1.4.4]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.0...v1.4.1

--- a/README.md
+++ b/README.md
@@ -430,22 +430,19 @@ Stable output characteristics to aid tooling & reproducibility:
 
 ### Changelog
 
-**Latest Release: v1.4.3 (2026-07-21)**
+**Latest Release: v1.4.4 (2026-09-03)**
 
-LoRA Manager hash/path-resolution fixes, extra-metadata robustness, bugfixes, and UI enhancements:
-- **LoRA Manager fixes**: Hash calculation now works with structured payloads; extra paths included for LoRAs, embeddings, checkpoints, and UNets with path deduplication.
-- **Extra metadata**: Commas are no longer replaced in values; dynamic key-value pair count replaces hardcoded 4-pair limit.
-- **Bugfixes**: Efficiency nodes now accept tuple batches for advanced mode; validator connection cache invalidates on prompt changes; redundant code removed.
-- **UI/UX**: Advanced toggle for log suppression; enhanced filename prefix tooltip with subdirectory support.
-- **CI**: Fork-PR lint-autofix checkout fixed.
+Fix for a metadata capture crash on list-of-dicts widget values:
+- **Crash fix**: `Trace.trace` and the prompt validator now use the shared `_is_link_input` predicate, so list-of-dicts widget values (such as LoRA stacks) are skipped instead of crashing with `TypeError: unhashable type: 'dict'`. (#145)
 
 **Recent Prior Releases**
 
+- **v1.4.3 (2026-07-21)**: LoRA Manager hash/path-resolution fixes, extra-metadata robustness, bugfixes, and UI enhancements.
 - **v1.4.2 (2026-03-19)**: Prompt-routing and metadata-validation hardening release.
 - **v1.4.1 (2026-03-18)**: Save Image widget ordering and fit hotfix release.
 - **v1.4.0 (2026-03-17)**: ComfyUI 0.3.65+ compatibility, `lora_strengths_in_prompt`, and extension hardening release.
 
-See [CHANGELOG.md](CHANGELOG.md) for complete details or [RELEASE_NOTES_v1.4.3.md](docs/releases/RELEASE_NOTES_v1.4.3.md) for the full release notes.
+See [CHANGELOG.md](CHANGELOG.md) for complete details or [RELEASE_NOTES_v1.4.4.md](docs/releases/RELEASE_NOTES_v1.4.4.md) for the full release notes.
 
 **Previous Notable Changes:**
 - Refactor notice: legacy monolithic module removed; see [CHANGELOG.md](CHANGELOG.md) for new direct import paths

--- a/docs/releases/RELEASE_NOTES_v1.4.4.md
+++ b/docs/releases/RELEASE_NOTES_v1.4.4.md
@@ -25,7 +25,7 @@ and aborted the save. The fix is backward-compatible with no migration required.
 
 - Added regression tests that feed a bare list-of-dicts input through the tracer and assert it is skipped
   without crashing.
-- `python -m pytest -q` passes for the affected modules; `python -m ruff check .` passes cleanly.
+- `python -m pytest -q`: 1164 passed, 1 skipped; `python -m ruff check .` passes cleanly.
 
 ## Breaking Changes
 

--- a/docs/releases/RELEASE_NOTES_v1.4.4.md
+++ b/docs/releases/RELEASE_NOTES_v1.4.4.md
@@ -1,0 +1,42 @@
+# Release Notes — v1.4.4
+
+**Release Date:** 2026-09-03
+**Commits:** 1 merged PR since v1.4.3
+**Tag:** [`v1.4.4`](https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/releases/tag/v1.4.4)
+
+## Overview
+
+Version 1.4.4 is a patch release that fixes a metadata capture crash. When a list-of-dicts widget value
+(such as a LoRA stack) sits upstream of the save node, the tracer raised `TypeError: unhashable type: 'dict'`
+and aborted the save. The fix is backward-compatible with no migration required.
+
+## Highlights
+
+### Crash Fix: List-of-Dicts Widget Values in the Tracer
+
+- `Trace.trace` treated every list-valued input as a graph link and hashed its first element. For a
+  list-of-dicts widget value (e.g. `[{"name": "...", "strength": ...}]`), the first element is a dict and
+  hashing it raised `TypeError: unhashable type: 'dict'`. (#145)
+- `Trace.trace` now uses the shared `_is_link_input` predicate, and `_get_node_id_list` in `validators.py`
+  guards its initial conditioning link, so non-link list values are skipped instead of hashed. This also
+  fixes a latent `IndexError` on empty-list inputs and aligns the two tracers. (#145)
+
+### Testing and Validation
+
+- Added regression tests that feed a bare list-of-dicts input through the tracer and assert it is skipped
+  without crashing.
+- `python -m pytest -q` passes for the affected modules; `python -m ruff check .` passes cleanly.
+
+## Breaking Changes
+
+None.
+
+## Upgrade Notes
+
+No migration is required. Update the node pack and restart ComfyUI — the change only affects graph
+traversal during metadata capture and is fully backward-compatible.
+
+## What's Changed
+* Fix trace crash on list-of-dicts widget values by @EnragedAntelope in https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/pull/145
+
+**Full Changelog**: https://github.com/xxmjskxx/ComfyUI_SaveImageWithMetaDataUniversal/compare/v1.4.3...v1.4.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "SaveImageWithMetaDataUniversal"
 description = """
 Node for saving PNGs, WEBPs, and JPEGs with rich automatically captured metadata from any node: prompts, model/VAE/LoRA names & hashes, sampler & scheduler (Civitai-compatible), optional workflow embedding, dynamic rule scanning + forced include system, deterministic ordering, filename tokens, and staged JPEG metadata fallback.
 """
-version = "1.4.3"
+version = "1.4.4"
 license = { file = "LICENSE" }
 dependencies = [
     "pillow>=10.0.0",


### PR DESCRIPTION
## Summary

Release v1.4.4 — a patch release fixing a metadata capture crash.

## What's included

- **Crash fix**: `Trace.trace` and the prompt validator now use the shared `_is_link_input` predicate, so list-of-dicts widget values (such as LoRA stacks) upstream of the save node are skipped instead of crashing with `TypeError: unhashable type: 'dict'`. (#145)
- **Version bump**: `pyproject.toml` version bumped to `1.4.4`.
- **Changelog**: new `[1.4.4]` section added to `CHANGELOG.md`.
- **Release notes**: `docs/releases/RELEASE_NOTES_v1.4.4.md` added.
- **README**: latest-release section updated to v1.4.4.

## Testing

- `python -m pytest -q`: 1164 passed, 1 skipped.
- `python -m ruff check .`: clean.

## Notes

No breaking changes and no migration required. See [RELEASE_NOTES_v1.4.4.md](docs/releases/RELEASE_NOTES_v1.4.4.md) for full details.